### PR TITLE
feat: Add Dependency-Track integration

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ArtifactKeeperApi.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ArtifactKeeperApi.kt
@@ -64,6 +64,16 @@ import com.artifactkeeper.android.data.models.PromotionResponse
 import com.artifactkeeper.android.data.models.BulkPromoteRequest
 import com.artifactkeeper.android.data.models.BulkPromotionResponse
 import com.artifactkeeper.android.data.models.PromotionHistoryResponse
+import com.artifactkeeper.android.data.models.DtStatus
+import com.artifactkeeper.android.data.models.DtProject
+import com.artifactkeeper.android.data.models.DtFinding
+import com.artifactkeeper.android.data.models.DtComponentFull
+import com.artifactkeeper.android.data.models.DtProjectMetrics
+import com.artifactkeeper.android.data.models.DtPortfolioMetrics
+import com.artifactkeeper.android.data.models.DtPolicyViolation
+import com.artifactkeeper.android.data.models.DtAnalysisResponse
+import com.artifactkeeper.android.data.models.DtPolicyFull
+import com.artifactkeeper.android.data.models.UpdateDtAnalysisRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -333,4 +343,38 @@ interface ArtifactKeeperApi {
         @Query("page") page: Int = 1,
         @Query("per_page") perPage: Int = 50,
     ): PromotionHistoryResponse
+
+    // --- Dependency-Track ---
+    @GET("api/v1/dependency-track/status")
+    suspend fun getDtStatus(): DtStatus
+
+    @GET("api/v1/dependency-track/projects")
+    suspend fun getDtProjects(): List<DtProject>
+
+    @GET("api/v1/dependency-track/projects/{uuid}/findings")
+    suspend fun getDtFindings(@Path("uuid") projectUuid: String): List<DtFinding>
+
+    @GET("api/v1/dependency-track/projects/{uuid}/components")
+    suspend fun getDtComponents(@Path("uuid") projectUuid: String): List<DtComponentFull>
+
+    @GET("api/v1/dependency-track/projects/{uuid}/metrics")
+    suspend fun getDtProjectMetrics(@Path("uuid") projectUuid: String): DtProjectMetrics
+
+    @GET("api/v1/dependency-track/projects/{uuid}/metrics/history")
+    suspend fun getDtProjectMetricsHistory(
+        @Path("uuid") projectUuid: String,
+        @Query("days") days: Int = 30,
+    ): List<DtProjectMetrics>
+
+    @GET("api/v1/dependency-track/metrics/portfolio")
+    suspend fun getDtPortfolioMetrics(): DtPortfolioMetrics
+
+    @GET("api/v1/dependency-track/projects/{uuid}/violations")
+    suspend fun getDtProjectViolations(@Path("uuid") projectUuid: String): List<DtPolicyViolation>
+
+    @PUT("api/v1/dependency-track/analysis")
+    suspend fun updateDtAnalysis(@Body request: UpdateDtAnalysisRequest): DtAnalysisResponse
+
+    @GET("api/v1/dependency-track/policies")
+    suspend fun getDtPolicies(): List<DtPolicyFull>
 }

--- a/app/src/main/java/com/artifactkeeper/android/data/api/ArtifactKeeperApi.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ArtifactKeeperApi.kt
@@ -74,6 +74,10 @@ import com.artifactkeeper.android.data.models.DtPolicyViolation
 import com.artifactkeeper.android.data.models.DtAnalysisResponse
 import com.artifactkeeper.android.data.models.DtPolicyFull
 import com.artifactkeeper.android.data.models.UpdateDtAnalysisRequest
+import com.artifactkeeper.android.data.models.VirtualMembersResponse
+import com.artifactkeeper.android.data.models.VirtualMember
+import com.artifactkeeper.android.data.models.AddMemberRequest
+import com.artifactkeeper.android.data.models.ReorderMembersRequest
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -377,4 +381,26 @@ interface ArtifactKeeperApi {
 
     @GET("api/v1/dependency-track/policies")
     suspend fun getDtPolicies(): List<DtPolicyFull>
+
+    // --- Virtual Repository Members ---
+    @GET("api/v1/repositories/{key}/members")
+    suspend fun listVirtualMembers(@Path("key") repoKey: String): VirtualMembersResponse
+
+    @POST("api/v1/repositories/{key}/members")
+    suspend fun addVirtualMember(
+        @Path("key") repoKey: String,
+        @Body request: AddMemberRequest,
+    ): VirtualMember
+
+    @DELETE("api/v1/repositories/{key}/members/{memberKey}")
+    suspend fun removeVirtualMember(
+        @Path("key") repoKey: String,
+        @Path("memberKey") memberKey: String,
+    )
+
+    @PUT("api/v1/repositories/{key}/members")
+    suspend fun reorderVirtualMembers(
+        @Path("key") repoKey: String,
+        @Body request: ReorderMembersRequest,
+    ): VirtualMembersResponse
 }

--- a/app/src/main/java/com/artifactkeeper/android/data/models/Models.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/models/Models.kt
@@ -1008,3 +1008,38 @@ data class UpdateDtAnalysisRequest(
     val details: String? = null,
     val suppressed: Boolean = false,
 )
+
+// --- Virtual Repository Members ---
+
+@Serializable
+data class VirtualMember(
+    val id: String,
+    @SerialName("member_repo_id") val memberRepoId: String,
+    @SerialName("member_repo_key") val memberRepoKey: String,
+    @SerialName("member_repo_name") val memberRepoName: String,
+    @SerialName("member_repo_type") val memberRepoType: String,
+    val priority: Int,
+    @SerialName("created_at") val createdAt: String,
+)
+
+@Serializable
+data class VirtualMembersResponse(
+    val items: List<VirtualMember>,
+)
+
+@Serializable
+data class AddMemberRequest(
+    @SerialName("member_key") val memberKey: String,
+    val priority: Int? = null,
+)
+
+@Serializable
+data class MemberPriority(
+    @SerialName("member_key") val memberKey: String,
+    val priority: Int,
+)
+
+@Serializable
+data class ReorderMembersRequest(
+    val members: List<MemberPriority>,
+)

--- a/app/src/main/java/com/artifactkeeper/android/data/models/Models.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/models/Models.kt
@@ -817,3 +817,194 @@ data class PromotionHistoryResponse(
     val items: List<PromotionHistoryEntry>,
     val pagination: Pagination? = null,
 )
+
+// --- Dependency-Track Integration ---
+
+@Serializable
+data class DtStatus(
+    val enabled: Boolean,
+    val healthy: Boolean,
+    val url: String? = null,
+)
+
+@Serializable
+data class DtProject(
+    val uuid: String,
+    val name: String,
+    val version: String? = null,
+    val description: String? = null,
+    @SerialName("lastBomImport") val lastBomImport: Long? = null,
+    @SerialName("lastBomImportFormat") val lastBomImportFormat: String? = null,
+)
+
+@Serializable
+data class DtComponent(
+    val uuid: String,
+    val name: String,
+    val version: String? = null,
+    val group: String? = null,
+    val purl: String? = null,
+)
+
+@Serializable
+data class DtCwe(
+    @SerialName("cweId") val cweId: Int,
+    val name: String,
+)
+
+@Serializable
+data class DtVulnerability(
+    val uuid: String,
+    @SerialName("vulnId") val vulnId: String,
+    val source: String,
+    val severity: String,
+    val title: String? = null,
+    val description: String? = null,
+    @SerialName("cvssV3BaseScore") val cvssV3BaseScore: Double? = null,
+    val cwe: DtCwe? = null,
+)
+
+@Serializable
+data class DtAnalysis(
+    val state: String? = null,
+    val justification: String? = null,
+    val response: String? = null,
+    val details: String? = null,
+    @SerialName("isSuppressed") val isSuppressed: Boolean = false,
+)
+
+@Serializable
+data class DtAttribution(
+    @SerialName("analyzerIdentity") val analyzerIdentity: String? = null,
+    @SerialName("attributedOn") val attributedOn: Long? = null,
+)
+
+@Serializable
+data class DtFinding(
+    val component: DtComponent,
+    val vulnerability: DtVulnerability,
+    val analysis: DtAnalysis? = null,
+    val attribution: DtAttribution? = null,
+)
+
+@Serializable
+data class DtProjectMetrics(
+    val critical: Long = 0,
+    val high: Long = 0,
+    val medium: Long = 0,
+    val low: Long = 0,
+    val unassigned: Long = 0,
+    val vulnerabilities: Long? = null,
+    @SerialName("findingsTotal") val findingsTotal: Long = 0,
+    @SerialName("findingsAudited") val findingsAudited: Long = 0,
+    @SerialName("findingsUnaudited") val findingsUnaudited: Long = 0,
+    val suppressions: Long = 0,
+    @SerialName("inheritedRiskScore") val inheritedRiskScore: Double = 0.0,
+    @SerialName("policyViolationsFail") val policyViolationsFail: Long = 0,
+    @SerialName("policyViolationsWarn") val policyViolationsWarn: Long = 0,
+    @SerialName("policyViolationsInfo") val policyViolationsInfo: Long = 0,
+    @SerialName("policyViolationsTotal") val policyViolationsTotal: Long = 0,
+    @SerialName("firstOccurrence") val firstOccurrence: Long? = null,
+    @SerialName("lastOccurrence") val lastOccurrence: Long? = null,
+)
+
+@Serializable
+data class DtPortfolioMetrics(
+    val critical: Long = 0,
+    val high: Long = 0,
+    val medium: Long = 0,
+    val low: Long = 0,
+    val unassigned: Long = 0,
+    val vulnerabilities: Long? = null,
+    @SerialName("findingsTotal") val findingsTotal: Long = 0,
+    @SerialName("findingsAudited") val findingsAudited: Long = 0,
+    @SerialName("findingsUnaudited") val findingsUnaudited: Long = 0,
+    val suppressions: Long = 0,
+    @SerialName("inheritedRiskScore") val inheritedRiskScore: Double = 0.0,
+    @SerialName("policyViolationsFail") val policyViolationsFail: Long = 0,
+    @SerialName("policyViolationsWarn") val policyViolationsWarn: Long = 0,
+    @SerialName("policyViolationsInfo") val policyViolationsInfo: Long = 0,
+    @SerialName("policyViolationsTotal") val policyViolationsTotal: Long = 0,
+    val projects: Long = 0,
+)
+
+@Serializable
+data class DtLicense(
+    val uuid: String? = null,
+    @SerialName("licenseId") val licenseId: String? = null,
+    val name: String,
+)
+
+@Serializable
+data class DtComponentFull(
+    val uuid: String,
+    val name: String,
+    val version: String? = null,
+    val group: String? = null,
+    val purl: String? = null,
+    val cpe: String? = null,
+    @SerialName("resolvedLicense") val resolvedLicense: DtLicense? = null,
+    @SerialName("isInternal") val isInternal: Boolean? = null,
+)
+
+@Serializable
+data class DtPolicy(
+    val uuid: String,
+    val name: String,
+    @SerialName("violationState") val violationState: String,
+)
+
+@Serializable
+data class DtPolicyCondition(
+    val uuid: String,
+    val subject: String,
+    val operator: String,
+    val value: String,
+    val policy: DtPolicy,
+)
+
+@Serializable
+data class DtPolicyConditionFull(
+    val uuid: String,
+    val subject: String,
+    val operator: String,
+    val value: String,
+)
+
+@Serializable
+data class DtPolicyViolation(
+    val uuid: String,
+    @SerialName("type") val violationType: String,
+    val component: DtComponent,
+    @SerialName("policyCondition") val policyCondition: DtPolicyCondition,
+)
+
+@Serializable
+data class DtPolicyFull(
+    val uuid: String,
+    val name: String,
+    @SerialName("violationState") val violationState: String,
+    @SerialName("includeChildren") val includeChildren: Boolean? = null,
+    @SerialName("policyConditions") val policyConditions: List<DtPolicyConditionFull> = emptyList(),
+    val projects: List<DtProject> = emptyList(),
+    val tags: List<kotlinx.serialization.json.JsonElement> = emptyList(),
+)
+
+@Serializable
+data class DtAnalysisResponse(
+    @SerialName("analysisState") val analysisState: String,
+    @SerialName("analysisJustification") val analysisJustification: String? = null,
+    @SerialName("analysisDetails") val analysisDetails: String? = null,
+    @SerialName("isSuppressed") val isSuppressed: Boolean = false,
+)
+
+@Serializable
+data class UpdateDtAnalysisRequest(
+    @SerialName("project_uuid") val projectUuid: String,
+    @SerialName("component_uuid") val componentUuid: String,
+    @SerialName("vulnerability_uuid") val vulnerabilityUuid: String,
+    val state: String,
+    val justification: String? = null,
+    val details: String? = null,
+    val suppressed: Boolean = false,
+)

--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -42,6 +42,7 @@ import com.artifactkeeper.android.ui.screens.operations.TelemetryScreen
 import com.artifactkeeper.android.ui.screens.packages.PackagesScreen
 import com.artifactkeeper.android.ui.screens.repositories.RepositoriesScreen
 import com.artifactkeeper.android.ui.screens.repositories.RepositoryDetailScreen
+import com.artifactkeeper.android.ui.screens.repositories.VirtualMembersScreen
 import com.artifactkeeper.android.ui.screens.search.SearchScreen
 import com.artifactkeeper.android.ui.screens.security.LicensePoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.PoliciesScreen
@@ -384,6 +385,20 @@ private fun MainAppScaffold(
                     RepositoryDetailScreen(
                         repoKey = key,
                         onBack = { navController.popBackStack() },
+                        onNavigateToMembers = { repoKey, repoName, repoFormat ->
+                            navController.navigate("repos/$repoKey/members?name=$repoName&format=$repoFormat")
+                        },
+                    )
+                }
+                composable("repos/{key}/members?name={name}&format={format}") { backStackEntry ->
+                    val key = backStackEntry.arguments?.getString("key") ?: return@composable
+                    val name = backStackEntry.arguments?.getString("name") ?: key
+                    val format = backStackEntry.arguments?.getString("format") ?: ""
+                    VirtualMembersScreen(
+                        repoKey = key,
+                        repoName = name,
+                        repoFormat = format,
+                        onBack = { navController.popBackStack() },
                     )
                 }
             }
@@ -440,6 +455,20 @@ private fun MainAppScaffold(
                     val key = backStackEntry.arguments?.getString("key") ?: return@composable
                     RepositoryDetailScreen(
                         repoKey = key,
+                        onBack = { navController.popBackStack() },
+                        onNavigateToMembers = { repoKey, repoName, repoFormat ->
+                            navController.navigate("repos/$repoKey/members?name=$repoName&format=$repoFormat")
+                        },
+                    )
+                }
+                composable("repos/{key}/members?name={name}&format={format}") { backStackEntry ->
+                    val key = backStackEntry.arguments?.getString("key") ?: return@composable
+                    val name = backStackEntry.arguments?.getString("name") ?: key
+                    val format = backStackEntry.arguments?.getString("format") ?: ""
+                    VirtualMembersScreen(
+                        repoKey = key,
+                        repoName = name,
+                        repoFormat = format,
                         onBack = { navController.popBackStack() },
                     )
                 }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
@@ -8,7 +8,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -28,7 +30,11 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RepositoryDetailScreen(repoKey: String, onBack: () -> Unit) {
+fun RepositoryDetailScreen(
+    repoKey: String,
+    onBack: () -> Unit,
+    onNavigateToMembers: ((repoKey: String, repoName: String, repoFormat: String) -> Unit)? = null,
+) {
     var repository by remember { mutableStateOf<Repository?>(null) }
     var artifacts by remember { mutableStateOf<List<Artifact>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
@@ -113,6 +119,17 @@ fun RepositoryDetailScreen(repoKey: String, onBack: () -> Unit) {
                         repository?.let { repo ->
                             item(key = "header") {
                                 RepoDetailHeader(repo)
+                            }
+
+                            // Members card for virtual repositories
+                            if (repo.repoType.equals("virtual", ignoreCase = true)) {
+                                item(key = "members") {
+                                    VirtualMembersCard(
+                                        onClick = {
+                                            onNavigateToMembers?.invoke(repo.key, repo.name, repo.format)
+                                        },
+                                    )
+                                }
                             }
                         }
 
@@ -308,6 +325,46 @@ private fun ArtifactCard(artifact: Artifact, repoKey: String) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun VirtualMembersCard(onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.Groups,
+                contentDescription = "Members",
+                modifier = Modifier.size(24.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Member Repositories",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = "Manage local and remote repositories included in this virtual repository",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = "Navigate",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/VirtualMembersScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/VirtualMembersScreen.kt
@@ -1,0 +1,435 @@
+package com.artifactkeeper.android.ui.screens.repositories
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.artifactkeeper.android.data.models.Repository
+import com.artifactkeeper.android.data.models.VirtualMember
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VirtualMembersScreen(
+    repoKey: String,
+    repoName: String,
+    repoFormat: String,
+    onBack: () -> Unit,
+    viewModel: VirtualMembersViewModel = viewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    var showAddDialog by remember { mutableStateOf(false) }
+    var memberToDelete by remember { mutableStateOf<VirtualMember?>(null) }
+
+    // Track dragging state
+    var draggedItemIndex by remember { mutableIntStateOf(-1) }
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+
+    LaunchedEffect(repoKey) {
+        viewModel.loadMembers(repoKey)
+    }
+
+    // Show error/success messages
+    LaunchedEffect(uiState.error, uiState.successMessage) {
+        uiState.error?.let { error ->
+            snackbarHostState.showSnackbar(error)
+            viewModel.clearMessages()
+        }
+        uiState.successMessage?.let { msg ->
+            snackbarHostState.showSnackbar(msg)
+            viewModel.clearMessages()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("$repoName Members") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {
+                    viewModel.loadEligibleRepos(repoKey, repoFormat)
+                    showAddDialog = true
+                },
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Add Member")
+            }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { paddingValues ->
+        when {
+            uiState.isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            uiState.members.isEmpty() -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "No members",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Add local or remote repositories as members",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            else -> {
+                val listState = rememberLazyListState()
+                val members = uiState.members
+
+                PullToRefreshBox(
+                    isRefreshing = uiState.isLoading,
+                    onRefresh = { viewModel.loadMembers(repoKey) },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                ) {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        item {
+                            Text(
+                                text = "Drag to reorder. Lower priority = higher precedence.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(bottom = 8.dp),
+                            )
+                        }
+
+                        itemsIndexed(
+                            items = members,
+                            key = { _, member -> member.id },
+                        ) { index, member ->
+                            val isDragging = draggedItemIndex == index
+                            val elevation by animateDpAsState(
+                                targetValue = if (isDragging) 8.dp else 1.dp,
+                                label = "elevation",
+                            )
+
+                            MemberCard(
+                                member = member,
+                                index = index,
+                                isDragging = isDragging,
+                                elevation = elevation,
+                                dragOffset = if (isDragging) dragOffset else 0f,
+                                onDelete = { memberToDelete = member },
+                                onDragStart = { draggedItemIndex = index },
+                                onDrag = { delta ->
+                                    dragOffset += delta
+                                    // Calculate new index based on drag offset
+                                    val itemHeight = 80f // Approximate item height in dp
+                                    val indexOffset = (dragOffset / itemHeight).toInt()
+                                    val newIndex = (index + indexOffset).coerceIn(0, members.lastIndex)
+                                    if (newIndex != index && newIndex != draggedItemIndex) {
+                                        // Reorder the list
+                                        val mutableList = members.toMutableList()
+                                        val draggedItem = mutableList.removeAt(draggedItemIndex)
+                                        mutableList.add(newIndex, draggedItem)
+                                        draggedItemIndex = newIndex
+                                        dragOffset = 0f
+                                    }
+                                },
+                                onDragEnd = {
+                                    if (draggedItemIndex != index) {
+                                        // Create reordered list with new priorities
+                                        val reorderedMembers = members.toMutableList()
+                                        val draggedItem = reorderedMembers.removeAt(index)
+                                        reorderedMembers.add(draggedItemIndex.coerceIn(0, reorderedMembers.size), draggedItem)
+                                        viewModel.reorderMembers(reorderedMembers)
+                                    }
+                                    draggedItemIndex = -1
+                                    dragOffset = 0f
+                                },
+                                onDragCancel = {
+                                    draggedItemIndex = -1
+                                    dragOffset = 0f
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Add Member Dialog
+    if (showAddDialog) {
+        AddMemberDialog(
+            eligibleRepos = uiState.eligibleRepos,
+            isLoading = uiState.isLoadingEligible,
+            onDismiss = { showAddDialog = false },
+            onAdd = { repo ->
+                viewModel.addMember(repo.key)
+                showAddDialog = false
+            },
+        )
+    }
+
+    // Delete Confirmation Dialog
+    memberToDelete?.let { member ->
+        AlertDialog(
+            onDismissRequest = { memberToDelete = null },
+            title = { Text("Remove Member") },
+            text = { Text("Remove ${member.memberRepoName} from this virtual repository?") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.removeMember(member.memberRepoKey)
+                        memberToDelete = null
+                    },
+                ) {
+                    Text("Remove")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { memberToDelete = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun MemberCard(
+    member: VirtualMember,
+    index: Int,
+    isDragging: Boolean,
+    elevation: androidx.compose.ui.unit.Dp,
+    dragOffset: Float,
+    onDelete: () -> Unit,
+    onDragStart: () -> Unit,
+    onDrag: (Float) -> Unit,
+    onDragEnd: () -> Unit,
+    onDragCancel: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .graphicsLayer {
+                translationY = if (isDragging) dragOffset else 0f
+            }
+            .shadow(elevation)
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Drag handle
+            Icon(
+                Icons.Default.DragHandle,
+                contentDescription = "Drag to reorder",
+                modifier = Modifier
+                    .pointerInput(Unit) {
+                        detectDragGesturesAfterLongPress(
+                            onDragStart = { onDragStart() },
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                onDrag(dragAmount.y)
+                            },
+                            onDragEnd = { onDragEnd() },
+                            onDragCancel = { onDragCancel() },
+                        )
+                    },
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            // Priority badge
+            Surface(
+                shape = MaterialTheme.shapes.small,
+                color = MaterialTheme.colorScheme.primaryContainer,
+            ) {
+                Text(
+                    text = "${member.priority}",
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            // Member info
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = member.memberRepoName,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(top = 4.dp),
+                ) {
+                    AssistChip(
+                        onClick = {},
+                        label = {
+                            Text(
+                                member.memberRepoType.uppercase(),
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        },
+                    )
+                    Text(
+                        text = member.memberRepoKey,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // Delete button
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Remove member",
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddMemberDialog(
+    eligibleRepos: List<Repository>,
+    isLoading: Boolean,
+    onDismiss: () -> Unit,
+    onAdd: (Repository) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add Member Repository") },
+        text = {
+            Column {
+                when {
+                    isLoading -> {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(200.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
+                    eligibleRepos.isEmpty() -> {
+                        Text(
+                            text = "No eligible repositories found. Only local and remote repositories with the same format can be added as members.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    else -> {
+                        Text(
+                            text = "Select a repository to add as a member:",
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(bottom = 16.dp),
+                        )
+                        LazyColumn(
+                            modifier = Modifier.heightIn(max = 300.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            items(
+                                count = eligibleRepos.size,
+                                key = { eligibleRepos[it].id },
+                            ) { index ->
+                                val repo = eligibleRepos[index]
+                                ElevatedCard(
+                                    onClick = { onAdd(repo) },
+                                    modifier = Modifier.fillMaxWidth(),
+                                ) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(12.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Column(modifier = Modifier.weight(1f)) {
+                                            Text(
+                                                text = repo.name,
+                                                style = MaterialTheme.typography.titleSmall,
+                                            )
+                                            Text(
+                                                text = repo.key,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                        AssistChip(
+                                            onClick = {},
+                                            label = {
+                                                Text(
+                                                    repo.repoType.uppercase(),
+                                                    style = MaterialTheme.typography.labelSmall,
+                                                )
+                                            },
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/VirtualMembersViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/VirtualMembersViewModel.kt
@@ -1,0 +1,151 @@
+package com.artifactkeeper.android.ui.screens.repositories
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.models.AddMemberRequest
+import com.artifactkeeper.android.data.models.MemberPriority
+import com.artifactkeeper.android.data.models.ReorderMembersRequest
+import com.artifactkeeper.android.data.models.Repository
+import com.artifactkeeper.android.data.models.VirtualMember
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class VirtualMembersUiState(
+    val members: List<VirtualMember> = emptyList(),
+    val eligibleRepos: List<Repository> = emptyList(),
+    val isLoading: Boolean = false,
+    val isLoadingEligible: Boolean = false,
+    val isSaving: Boolean = false,
+    val error: String? = null,
+    val successMessage: String? = null,
+)
+
+class VirtualMembersViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(VirtualMembersUiState())
+    val uiState: StateFlow<VirtualMembersUiState> = _uiState.asStateFlow()
+
+    private var currentRepoKey: String = ""
+
+    fun loadMembers(repoKey: String) {
+        currentRepoKey = repoKey
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val response = ApiClient.api.listVirtualMembers(repoKey)
+                _uiState.update {
+                    it.copy(
+                        members = response.items.sortedBy { member -> member.priority },
+                        isLoading = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load members",
+                        isLoading = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun loadEligibleRepos(repoKey: String, repoFormat: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingEligible = true) }
+            try {
+                val response = ApiClient.api.listRepositories()
+                // Filter to local and remote repos of the same format
+                // Exclude repos that are already members
+                val currentMemberKeys = _uiState.value.members.map { it.memberRepoKey }.toSet()
+                val eligible = response.items.filter { repo ->
+                    repo.key != repoKey &&
+                    repo.format.equals(repoFormat, ignoreCase = true) &&
+                    (repo.repoType.equals("local", ignoreCase = true) ||
+                     repo.repoType.equals("remote", ignoreCase = true)) &&
+                    repo.key !in currentMemberKeys
+                }
+                _uiState.update { it.copy(eligibleRepos = eligible, isLoadingEligible = false) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(isLoadingEligible = false) }
+            }
+        }
+    }
+
+    fun addMember(memberKey: String, priority: Int? = null) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null, successMessage = null) }
+            try {
+                val request = AddMemberRequest(memberKey = memberKey, priority = priority)
+                ApiClient.api.addVirtualMember(currentRepoKey, request)
+                _uiState.update { it.copy(isSaving = false, successMessage = "Member added") }
+                loadMembers(currentRepoKey)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to add member",
+                        isSaving = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun removeMember(memberKey: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null, successMessage = null) }
+            try {
+                ApiClient.api.removeVirtualMember(currentRepoKey, memberKey)
+                _uiState.update { it.copy(isSaving = false, successMessage = "Member removed") }
+                loadMembers(currentRepoKey)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to remove member",
+                        isSaving = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun reorderMembers(reorderedMembers: List<VirtualMember>) {
+        // Optimistically update UI
+        _uiState.update { it.copy(members = reorderedMembers) }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true, error = null, successMessage = null) }
+            try {
+                val memberPriorities = reorderedMembers.mapIndexed { index, member ->
+                    MemberPriority(memberKey = member.memberRepoKey, priority = index + 1)
+                }
+                val request = ReorderMembersRequest(members = memberPriorities)
+                val response = ApiClient.api.reorderVirtualMembers(currentRepoKey, request)
+                _uiState.update {
+                    it.copy(
+                        members = response.items.sortedBy { member -> member.priority },
+                        isSaving = false,
+                        successMessage = "Order saved",
+                    )
+                }
+            } catch (e: Exception) {
+                // Reload to restore correct state
+                loadMembers(currentRepoKey)
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to reorder members",
+                        isSaving = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun clearMessages() {
+        _uiState.update { it.copy(error = null, successMessage = null) }
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SecurityScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SecurityScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.models.DtPortfolioMetrics
+import com.artifactkeeper.android.data.models.DtStatus
 import com.artifactkeeper.android.data.models.RepoSecurityScore
 import com.artifactkeeper.android.data.models.Repository
 import com.artifactkeeper.android.ui.theme.Critical
@@ -29,6 +31,11 @@ private val GradeC = Color(0xFFFAAD14)
 private val GradeD = Color(0xFFFA8C16)
 private val GradeF = Color(0xFFF5222D)
 
+private val DtConnected = Color(0xFF52C41A)
+private val DtDisconnected = Color(0xFFF5222D)
+private val DtViolations = Color(0xFFFA8C16)
+private val DtProjects = Color(0xFF1890FF)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SecurityScreen() {
@@ -37,6 +44,8 @@ fun SecurityScreen() {
     var isLoading by remember { mutableStateOf(true) }
     var isRefreshing by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
+    var dtStatus by remember { mutableStateOf<DtStatus?>(null) }
+    var dtPortfolioMetrics by remember { mutableStateOf<DtPortfolioMetrics?>(null) }
     val coroutineScope = rememberCoroutineScope()
 
     fun loadData(refresh: Boolean = false) {
@@ -47,6 +56,20 @@ fun SecurityScreen() {
                 scores = ApiClient.api.getSecurityScores()
                 val repos = ApiClient.api.listRepositories(perPage = 100).items
                 repoMap = repos.associateBy { it.id }
+
+                // Load Dependency-Track status (non-blocking)
+                try {
+                    val status = ApiClient.api.getDtStatus()
+                    dtStatus = status
+                    if (status.enabled && status.healthy) {
+                        dtPortfolioMetrics = ApiClient.api.getDtPortfolioMetrics()
+                    } else {
+                        dtPortfolioMetrics = null
+                    }
+                } catch (_: Exception) {
+                    dtStatus = null
+                    dtPortfolioMetrics = null
+                }
             } catch (e: Exception) {
                 errorMessage = e.message ?: "Failed to load security data"
             } finally {
@@ -86,7 +109,7 @@ fun SecurityScreen() {
                     }
                 }
             }
-            scores.isEmpty() -> {
+            scores.isEmpty() && dtStatus?.enabled != true -> {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
@@ -109,11 +132,198 @@ fun SecurityScreen() {
                         contentPadding = PaddingValues(16.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
+                        // Dependency-Track section (only when enabled)
+                        if (dtStatus?.enabled == true) {
+                            item(key = "dt-status") {
+                                DtStatusCard(dtStatus!!)
+                            }
+
+                            if (dtPortfolioMetrics != null) {
+                                item(key = "dt-metrics") {
+                                    DtPortfolioMetricsCard(dtPortfolioMetrics!!)
+                                }
+
+                                item(key = "dt-audit") {
+                                    DtAuditProgressCard(dtPortfolioMetrics!!)
+                                }
+                            }
+                        }
+
+                        // Existing security score cards
                         items(scores, key = { it.id }) { score ->
                             SecurityScoreCard(score, repoMap[score.repositoryId])
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DtStatusCard(status: DtStatus) {
+    val isHealthy = status.healthy
+    val statusColor = if (isHealthy) DtConnected else DtDisconnected
+    val statusText = if (isHealthy) "Connected" else "Disconnected"
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column {
+                Text(
+                    text = "Dependency-Track",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                if (status.url != null) {
+                    Text(
+                        text = status.url,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(statusColor.copy(alpha = 0.15f))
+                    .padding(horizontal = 12.dp, vertical = 6.dp),
+            ) {
+                Text(
+                    text = statusText,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = statusColor,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun DtPortfolioMetricsCard(metrics: DtPortfolioMetrics) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Portfolio Overview",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                DtMetricChip(
+                    label = "Critical",
+                    value = metrics.critical.toString(),
+                    color = Critical,
+                )
+                DtMetricChip(
+                    label = "High",
+                    value = metrics.high.toString(),
+                    color = High,
+                )
+                DtMetricChip(
+                    label = "Findings",
+                    value = metrics.findingsTotal.toString(),
+                    color = Medium,
+                )
+                DtMetricChip(
+                    label = "Violations",
+                    value = metrics.policyViolationsTotal.toString(),
+                    color = DtViolations,
+                )
+                DtMetricChip(
+                    label = "Projects",
+                    value = metrics.projects.toString(),
+                    color = DtProjects,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DtMetricChip(label: String, value: String, color: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(color.copy(alpha = 0.10f))
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = color,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = color.copy(alpha = 0.8f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DtAuditProgressCard(metrics: DtPortfolioMetrics) {
+    val total = metrics.findingsTotal
+    val audited = metrics.findingsAudited
+    val progress = if (total > 0) audited.toFloat() / total.toFloat() else 0f
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Audit Progress",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(8.dp)
+                    .clip(RoundedCornerShape(4.dp)),
+                color = DtConnected,
+                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "Audited $audited / $total",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "Risk Score: ${"%.1f".format(metrics.inheritedRiskScore)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium,
+                    color = when {
+                        metrics.inheritedRiskScore >= 70 -> Critical
+                        metrics.inheritedRiskScore >= 40 -> High
+                        metrics.inheritedRiskScore >= 10 -> Medium
+                        else -> DtConnected
+                    },
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- Added 15 Kotlin data classes for all Dependency-Track API response/request types (`DtStatus`, `DtProject`, `DtFinding`, `DtPortfolioMetrics`, `DtComponentFull`, `DtPolicyFull`, etc.) with proper `@Serializable` and `@SerialName` annotations
- Added 10 Retrofit endpoint methods for the `/api/v1/dependency-track/` proxy routes (status, projects, findings, components, metrics, violations, analysis, policies)
- Updated `SecurityScreen` to display a DT portfolio section at the top when DT is enabled: connection status indicator, vulnerability severity counts, policy violations, project count, and audit progress with risk score

## Design decisions
- DT data loading is non-blocking: if the DT status call fails, the screen gracefully falls back to showing only the existing security score cards
- When DT is disabled (`status.enabled=false`) or unhealthy, no DT UI is rendered at all
- Portfolio metrics and audit progress use the same Material 3 color scheme already established for severity levels (`Critical`, `High`, `Medium`, `Low`)
- All new models use `Long` for numeric counters to match the backend's `i64` types

## Test plan
- [ ] Verify `assembleDebug` compiles cleanly (confirmed locally)
- [ ] With DT disabled: SecurityScreen shows existing score cards only, no DT section
- [ ] With DT enabled + healthy: status card shows "Connected", portfolio metrics and audit progress render
- [ ] With DT enabled + unhealthy: status card shows "Disconnected", no metrics cards
- [ ] Pull-to-refresh reloads both security scores and DT data
- [ ] Verify all DT API endpoints return correct data via the proxy