### PR TITLE
feat: Add CVE trends dashboard and artifact security navigation

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -45,6 +45,7 @@ import com.artifactkeeper.android.ui.screens.repositories.RepositoryDetailScreen
 import com.artifactkeeper.android.ui.screens.search.SearchScreen
 import com.artifactkeeper.android.ui.screens.security.LicensePoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.PoliciesScreen
+import com.artifactkeeper.android.ui.screens.security.SbomScreen
 import com.artifactkeeper.android.ui.screens.security.ScanFindingsScreen
 import com.artifactkeeper.android.ui.screens.security.ScansScreen
 import com.artifactkeeper.android.ui.screens.security.SecurityScreen
@@ -384,6 +385,18 @@ private fun MainAppScaffold(
                     RepositoryDetailScreen(
                         repoKey = key,
                         onBack = { navController.popBackStack() },
+                        onArtifactSecurityClick = { id, name ->
+                            navController.navigate("artifacts/$id/security?name=$name")
+                        },
+                    )
+                }
+                composable("artifacts/{id}/security?name={name}") { backStackEntry ->
+                    val id = backStackEntry.arguments?.getString("id") ?: return@composable
+                    val name = backStackEntry.arguments?.getString("name") ?: "Artifact"
+                    SbomScreen(
+                        artifactId = id,
+                        artifactName = name,
+                        onBack = { navController.popBackStack() },
                     )
                 }
             }
@@ -440,6 +453,18 @@ private fun MainAppScaffold(
                     val key = backStackEntry.arguments?.getString("key") ?: return@composable
                     RepositoryDetailScreen(
                         repoKey = key,
+                        onBack = { navController.popBackStack() },
+                        onArtifactSecurityClick = { id, name ->
+                            navController.navigate("artifacts/$id/security?name=$name")
+                        },
+                    )
+                }
+                composable("artifacts/{id}/security?name={name}") { backStackEntry ->
+                    val id = backStackEntry.arguments?.getString("id") ?: return@composable
+                    val name = backStackEntry.arguments?.getString("name") ?: "Artifact"
+                    SbomScreen(
+                        artifactId = id,
+                        artifactName = name,
                         onBack = { navController.popBackStack() },
                     )
                 }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
@@ -28,7 +29,11 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun RepositoryDetailScreen(repoKey: String, onBack: () -> Unit) {
+fun RepositoryDetailScreen(
+    repoKey: String,
+    onBack: () -> Unit,
+    onArtifactSecurityClick: (id: String, name: String) -> Unit = { _, _ -> },
+) {
     var repository by remember { mutableStateOf<Repository?>(null) }
     var artifacts by remember { mutableStateOf<List<Artifact>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
@@ -155,7 +160,11 @@ fun RepositoryDetailScreen(repoKey: String, onBack: () -> Unit) {
                         }
 
                         items(artifacts, key = { it.id }) { artifact ->
-                            ArtifactCard(artifact, repoKey)
+                            ArtifactCard(
+                                artifact = artifact,
+                                repoKey = repoKey,
+                                onSecurityClick = { onArtifactSecurityClick(artifact.id, artifact.name) },
+                            )
                         }
                     }
                 }
@@ -233,7 +242,7 @@ private fun RepoDetailHeader(repo: Repository) {
 }
 
 @Composable
-private fun ArtifactCard(artifact: Artifact, repoKey: String) {
+private fun ArtifactCard(artifact: Artifact, repoKey: String, onSecurityClick: () -> Unit) {
     val context = LocalContext.current
 
     Card(
@@ -263,6 +272,17 @@ private fun ArtifactCard(artifact: Artifact, repoKey: String) {
                     AssistChip(
                         onClick = {},
                         label = { Text("v${artifact.version}", style = MaterialTheme.typography.labelSmall) },
+                    )
+                }
+                IconButton(
+                    onClick = onSecurityClick,
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Icon(
+                        Icons.Default.Shield,
+                        contentDescription = "SBOM & Security",
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.primary,
                     )
                 }
             }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SecurityScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SecurityScreen.kt
@@ -1,5 +1,6 @@
 package com.artifactkeeper.android.ui.screens.security
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -11,10 +12,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.models.CveTrendDataPoint
+import com.artifactkeeper.android.data.models.CveTrends
 import com.artifactkeeper.android.data.models.RepoSecurityScore
 import com.artifactkeeper.android.data.models.Repository
 import com.artifactkeeper.android.ui.theme.Critical
@@ -34,6 +40,7 @@ private val GradeF = Color(0xFFF5222D)
 fun SecurityScreen() {
     var scores by remember { mutableStateOf<List<RepoSecurityScore>>(emptyList()) }
     var repoMap by remember { mutableStateOf<Map<String, Repository>>(emptyMap()) }
+    var cveTrends by remember { mutableStateOf<CveTrends?>(null) }
     var isLoading by remember { mutableStateOf(true) }
     var isRefreshing by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
@@ -47,6 +54,11 @@ fun SecurityScreen() {
                 scores = ApiClient.api.getSecurityScores()
                 val repos = ApiClient.api.listRepositories(perPage = 100).items
                 repoMap = repos.associateBy { it.id }
+                try {
+                    cveTrends = ApiClient.api.getCveTrends()
+                } catch (_: Exception) {
+                    // CVE trends are optional
+                }
             } catch (e: Exception) {
                 errorMessage = e.message ?: "Failed to load security data"
             } finally {
@@ -86,18 +98,6 @@ fun SecurityScreen() {
                     }
                 }
             }
-            scores.isEmpty() -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = "No security scores available",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
             else -> {
                 PullToRefreshBox(
                     isRefreshing = isRefreshing,
@@ -109,8 +109,40 @@ fun SecurityScreen() {
                         contentPadding = PaddingValues(16.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
-                        items(scores, key = { it.id }) { score ->
-                            SecurityScoreCard(score, repoMap[score.repositoryId])
+                        cveTrends?.let { trends ->
+                            item(key = "cve-trends") {
+                                CveTrendsSummaryCard(trends)
+                            }
+                        }
+
+                        if (scores.isEmpty() && cveTrends == null) {
+                            item(key = "empty") {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 32.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Text(
+                                        text = "No security data available",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        }
+
+                        if (scores.isNotEmpty()) {
+                            item(key = "scores-header") {
+                                Text(
+                                    text = "Repository Scores",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    modifier = Modifier.padding(top = 4.dp),
+                                )
+                            }
+                            items(scores, key = { it.id }) { score ->
+                                SecurityScoreCard(score, repoMap[score.repositoryId])
+                            }
                         }
                     }
                 }
@@ -205,6 +237,103 @@ private fun SeverityPill(label: String, count: Int, color: Color) {
             style = MaterialTheme.typography.labelSmall,
             fontWeight = FontWeight.SemiBold,
             color = color,
+        )
+    }
+}
+
+// MARK: - CVE Trends Summary
+
+@Composable
+private fun CveTrendsSummaryCard(trends: CveTrends) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "CVE Trends",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Severity counts
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                SeverityPill(label = "Critical", count = trends.criticalCount, color = Critical)
+                SeverityPill(label = "High", count = trends.highCount, color = High)
+                SeverityPill(label = "Medium", count = trends.mediumCount, color = Medium)
+                SeverityPill(label = "Low", count = trends.lowCount, color = Low)
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Detected vs Resolved
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "${trends.totalDetected} detected",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Critical,
+                )
+                Text(
+                    text = "${trends.totalResolved} resolved",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = GradeA,
+                )
+                Text(
+                    text = trends.period,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // Sparkline
+            if (trends.trendData.size >= 2) {
+                Spacer(modifier = Modifier.height(12.dp))
+                CveTrendSparkline(
+                    data = trends.trendData,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CveTrendSparkline(data: List<CveTrendDataPoint>, modifier: Modifier = Modifier) {
+    val detectedColor = Critical
+    val resolvedColor = GradeA
+
+    Canvas(modifier = modifier) {
+        if (data.size < 2) return@Canvas
+
+        val maxVal = data.maxOf { maxOf(it.detected, it.resolved) }.coerceAtLeast(1).toFloat()
+        val stepX = size.width / (data.size - 1).toFloat()
+
+        fun buildPath(values: List<Int>): Path {
+            val path = Path()
+            values.forEachIndexed { i, v ->
+                val x = i * stepX
+                val y = size.height - (v.toFloat() / maxVal) * size.height
+                if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+            }
+            return path
+        }
+
+        drawPath(
+            path = buildPath(data.map { it.detected }),
+            color = detectedColor,
+            style = Stroke(width = 2.dp.toPx()),
+        )
+        drawPath(
+            path = buildPath(data.map { it.resolved }),
+            color = resolvedColor,
+            style = Stroke(width = 2.dp.toPx()),
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add **CVE trends summary card** to the Security dashboard showing critical/high/medium/low counts, total detected vs resolved, and a sparkline trend chart
- Wire **SbomScreen into artifact navigation**: each artifact card now has a shield icon that opens the SBOM & CVE history view
- Add `artifacts/{id}/security` composable route in both expanded and compact NavHost layouts

Closes #1

## Test plan
- [ ] Security tab > Dashboard shows CVE trends card above repo scores (when backend returns trend data)
- [ ] CVE trends card shows severity pills, detected/resolved counts, and sparkline
- [ ] Navigating to a repository and tapping the shield icon on an artifact opens the SBOM screen
- [ ] Back navigation from SBOM screen returns to repository detail
- [ ] Build succeeds with `./gradlew assembleDebug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)