### PR TITLE
Add edit repository dialog with key rename

### DIFF
--- a/sdk/src/main/kotlin/com/artifactkeeper/client/models/UpdateRepositoryRequest.kt
+++ b/sdk/src/main/kotlin/com/artifactkeeper/client/models/UpdateRepositoryRequest.kt
@@ -23,14 +23,18 @@ import kotlinx.serialization.Contextual
 /**
  * 
  *
- * @param description 
- * @param isPublic 
- * @param name 
- * @param quotaBytes 
+ * @param key
+ * @param description
+ * @param isPublic
+ * @param name
+ * @param quotaBytes
  */
 @Serializable
 
 data class UpdateRepositoryRequest (
+
+    @SerialName(value = "key")
+    val key: kotlin.String? = null,
 
     @SerialName(value = "description")
     val description: kotlin.String? = null,


### PR DESCRIPTION
## Summary
- Add `key` field to `UpdateRepositoryRequest` SDK model
- New `EditRepositoryDialog` composable in RepositoryDetailScreen
- Edit button in TopAppBar, navigates back on key change

## Changes
- `UpdateRepositoryRequest.kt` — add key field
- `RepositoryDetailScreen.kt` — edit button + dialog composable

## Test plan
- [ ] Build in Android Studio
- [ ] Manual: edit repo from detail screen, rename key