### PR TITLE
chore: add Mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,33 @@
+queue_rules:
+  - name: default
+    merge_method: squash
+    update_method: rebase
+
+pull_request_rules:
+  - name: Auto-merge Dependabot patch updates
+    conditions:
+      - author=dependabot[bot]
+      - "-title~=major"
+      - check-success=lint
+      - check-success=build
+      - check-success=test
+      - "#approved-reviews-by>=1"
+    actions:
+      queue:
+        name: default
+
+  - name: Flag Dependabot major updates
+    conditions:
+      - author=dependabot[bot]
+      - "title~=major"
+    actions:
+      label:
+        add:
+          - needs-review
+          - major-update
+
+  - name: Clean up merged branches
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}


### PR DESCRIPTION
## Summary
- Add Mergify configuration for automated PR management
- Auto-merge Dependabot patch/minor updates after lint, build, and test pass with approval
- Flag major dependency bumps for manual review
- Auto-delete merged branches
- Squash merge via merge queue

## Test plan
- [ ] Verify Mergify GitHub App is installed on the org
- [ ] Confirm rules activate on next PR