### PR TITLE
feat: add unit test suite

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,9 @@ dependencies {
 
     // Testing
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("app.cash.turbine:turbine:1.2.0")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.12.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/app/src/test/java/com/artifactkeeper/android/ApiClientTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/ApiClientTest.kt
@@ -1,0 +1,148 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApiClientTest {
+
+    @After
+    fun tearDown() {
+        // Reset ApiClient state after each test since it is a singleton
+        ApiClient.clearConfig()
+    }
+
+    // =========================================================================
+    // Initial / cleared state
+    // =========================================================================
+
+    @Test
+    fun `clearConfig resets to unconfigured state`() {
+        ApiClient.configure("https://example.com", "tok123")
+        ApiClient.clearConfig()
+
+        assertFalse(ApiClient.isConfigured)
+        assertEquals("", ApiClient.baseUrl)
+        assertNull(ApiClient.token)
+    }
+
+    // =========================================================================
+    // configure
+    // =========================================================================
+
+    @Test
+    fun `configure sets baseUrl and token`() {
+        ApiClient.configure("https://registry.example.com/", "my-token")
+
+        assertTrue(ApiClient.isConfigured)
+        assertEquals("https://registry.example.com/", ApiClient.baseUrl)
+        assertEquals("my-token", ApiClient.token)
+    }
+
+    @Test
+    fun `configure appends trailing slash if missing`() {
+        ApiClient.configure("https://registry.example.com")
+
+        assertEquals("https://registry.example.com/", ApiClient.baseUrl)
+    }
+
+    @Test
+    fun `configure does not double trailing slash`() {
+        ApiClient.configure("https://registry.example.com/")
+
+        assertEquals("https://registry.example.com/", ApiClient.baseUrl)
+    }
+
+    @Test
+    fun `configure with null token`() {
+        ApiClient.configure("https://registry.example.com/", null)
+
+        assertTrue(ApiClient.isConfigured)
+        assertNull(ApiClient.token)
+    }
+
+    @Test
+    fun `configure with default token parameter`() {
+        ApiClient.configure("https://registry.example.com/")
+
+        assertTrue(ApiClient.isConfigured)
+        assertNull(ApiClient.token)
+    }
+
+    // =========================================================================
+    // isConfigured
+    // =========================================================================
+
+    @Test
+    fun `isConfigured returns false when baseUrl is blank`() {
+        ApiClient.clearConfig()
+        assertFalse(ApiClient.isConfigured)
+    }
+
+    @Test
+    fun `isConfigured returns true when baseUrl is set`() {
+        ApiClient.configure("http://localhost:8080")
+        assertTrue(ApiClient.isConfigured)
+    }
+
+    // =========================================================================
+    // setToken
+    // =========================================================================
+
+    @Test
+    fun `setToken updates token`() {
+        ApiClient.configure("https://example.com")
+        assertNull(ApiClient.token)
+
+        ApiClient.setToken("new-token")
+        assertEquals("new-token", ApiClient.token)
+    }
+
+    @Test
+    fun `setToken with null clears token`() {
+        ApiClient.configure("https://example.com", "existing-token")
+        ApiClient.setToken(null)
+        assertNull(ApiClient.token)
+    }
+
+    // =========================================================================
+    // reconfigure overwrites previous values
+    // =========================================================================
+
+    @Test
+    fun `reconfigure overwrites previous baseUrl and token`() {
+        ApiClient.configure("https://server1.example.com", "token1")
+        assertEquals("https://server1.example.com/", ApiClient.baseUrl)
+        assertEquals("token1", ApiClient.token)
+
+        ApiClient.configure("https://server2.example.com", "token2")
+        assertEquals("https://server2.example.com/", ApiClient.baseUrl)
+        assertEquals("token2", ApiClient.token)
+    }
+
+    // =========================================================================
+    // URL edge cases
+    // =========================================================================
+
+    @Test
+    fun `configure with localhost URL`() {
+        ApiClient.configure("http://localhost:8080")
+        assertEquals("http://localhost:8080/", ApiClient.baseUrl)
+    }
+
+    @Test
+    fun `configure with IP address URL`() {
+        ApiClient.configure("http://192.168.1.100:8080")
+        assertEquals("http://192.168.1.100:8080/", ApiClient.baseUrl)
+    }
+
+    @Test
+    fun `configure with path in URL`() {
+        ApiClient.configure("https://example.com/api/v1")
+        assertEquals("https://example.com/api/v1/", ApiClient.baseUrl)
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/FormattingTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/FormattingTest.kt
@@ -1,0 +1,179 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.ui.util.formatBytes
+import com.artifactkeeper.android.ui.util.formatDownloadCount
+import com.artifactkeeper.android.ui.util.formatDuration
+import com.artifactkeeper.android.ui.util.formatRelativeTime
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+class FormattingTest {
+
+    // =========================================================================
+    // formatBytes
+    // =========================================================================
+
+    @Test
+    fun `formatBytes returns bytes for values under 1024`() {
+        assertEquals("0 B", formatBytes(0))
+        assertEquals("1 B", formatBytes(1))
+        assertEquals("512 B", formatBytes(512))
+        assertEquals("1023 B", formatBytes(1023))
+    }
+
+    @Test
+    fun `formatBytes returns KB for values in kilobyte range`() {
+        assertEquals("1.0 KB", formatBytes(1024))
+        assertEquals("1.5 KB", formatBytes(1536))
+        assertEquals("5.0 KB", formatBytes(5 * 1024))
+    }
+
+    @Test
+    fun `formatBytes drops decimal for values 10 KB and above`() {
+        assertEquals("10 KB", formatBytes(10 * 1024))
+        assertEquals("100 KB", formatBytes(100 * 1024))
+        assertEquals("999 KB", formatBytes(999 * 1024))
+    }
+
+    @Test
+    fun `formatBytes returns MB for megabyte range`() {
+        assertEquals("1.0 MB", formatBytes(1024L * 1024))
+        assertEquals("5.0 MB", formatBytes(5L * 1024 * 1024))
+        assertEquals("512 MB", formatBytes(512L * 1024 * 1024))
+    }
+
+    @Test
+    fun `formatBytes returns GB for gigabyte range`() {
+        assertEquals("1.0 GB", formatBytes(1024L * 1024 * 1024))
+        assertEquals("2.5 GB", formatBytes((2.5 * 1024 * 1024 * 1024).toLong()))
+    }
+
+    @Test
+    fun `formatBytes returns TB for terabyte range`() {
+        assertEquals("1.0 TB", formatBytes(1024L * 1024 * 1024 * 1024))
+        assertEquals("5.0 TB", formatBytes(5L * 1024 * 1024 * 1024 * 1024))
+    }
+
+    @Test
+    fun `formatBytes handles very large TB values`() {
+        // 100 TB should drop the decimal
+        assertEquals("100 TB", formatBytes(100L * 1024 * 1024 * 1024 * 1024))
+    }
+
+    // =========================================================================
+    // formatDuration
+    // =========================================================================
+
+    @Test
+    fun `formatDuration returns seconds only for short durations`() {
+        assertEquals("0s", formatDuration(0))
+        assertEquals("0s", formatDuration(999))
+        assertEquals("1s", formatDuration(1000))
+        assertEquals("59s", formatDuration(59_000))
+    }
+
+    @Test
+    fun `formatDuration returns minutes and seconds`() {
+        assertEquals("1m 0s", formatDuration(60_000))
+        assertEquals("1m 30s", formatDuration(90_000))
+        assertEquals("5m 15s", formatDuration(315_000))
+    }
+
+    @Test
+    fun `formatDuration returns hours minutes and seconds`() {
+        assertEquals("1h 0m 0s", formatDuration(3_600_000))
+        assertEquals("2h 30m 45s", formatDuration(9_045_000))
+    }
+
+    // =========================================================================
+    // formatRelativeTime (ISO string overload)
+    // =========================================================================
+
+    @Test
+    fun `formatRelativeTime returns just now for recent timestamps`() {
+        val now = Instant.now().toString()
+        assertEquals("just now", formatRelativeTime(now))
+    }
+
+    @Test
+    fun `formatRelativeTime returns minutes ago`() {
+        val fiveMinAgo = Instant.now().minus(5, ChronoUnit.MINUTES).toString()
+        assertEquals("5m ago", formatRelativeTime(fiveMinAgo))
+    }
+
+    @Test
+    fun `formatRelativeTime returns hours ago`() {
+        val threeHoursAgo = Instant.now().minus(3, ChronoUnit.HOURS).toString()
+        assertEquals("3h ago", formatRelativeTime(threeHoursAgo))
+    }
+
+    @Test
+    fun `formatRelativeTime returns days ago`() {
+        val twoDaysAgo = Instant.now().minus(2, ChronoUnit.DAYS).toString()
+        assertEquals("2d ago", formatRelativeTime(twoDaysAgo))
+    }
+
+    @Test
+    fun `formatRelativeTime returns formatted date for old timestamps`() {
+        val oldDate = Instant.parse("2023-01-15T10:00:00Z")
+        val result = formatRelativeTime(oldDate.toString())
+        // Should contain "Jan 15, 2023" (depending on system timezone, exact day may vary)
+        assertTrue(
+            "Expected formatted date containing 'Jan' and '2023', got: $result",
+            result.contains("2023") && result.contains("Jan")
+        )
+    }
+
+    @Test
+    fun `formatRelativeTime returns original string for invalid input`() {
+        assertEquals("not-a-date", formatRelativeTime("not-a-date"))
+        assertEquals("", formatRelativeTime(""))
+    }
+
+    // =========================================================================
+    // formatRelativeTime (OffsetDateTime overload)
+    // =========================================================================
+
+    @Test
+    fun `formatRelativeTime with OffsetDateTime returns just now`() {
+        val now = OffsetDateTime.now(ZoneOffset.UTC)
+        assertEquals("just now", formatRelativeTime(now))
+    }
+
+    @Test
+    fun `formatRelativeTime with OffsetDateTime returns minutes ago`() {
+        val tenMinAgo = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(10)
+        assertEquals("10m ago", formatRelativeTime(tenMinAgo))
+    }
+
+    // =========================================================================
+    // formatDownloadCount
+    // =========================================================================
+
+    @Test
+    fun `formatDownloadCount returns raw number below 1000`() {
+        assertEquals("0", formatDownloadCount(0))
+        assertEquals("1", formatDownloadCount(1))
+        assertEquals("999", formatDownloadCount(999))
+    }
+
+    @Test
+    fun `formatDownloadCount returns K suffix for thousands`() {
+        assertEquals("1.0K", formatDownloadCount(1_000))
+        assertEquals("1.5K", formatDownloadCount(1_500))
+        assertEquals("999.9K", formatDownloadCount(999_900))
+    }
+
+    @Test
+    fun `formatDownloadCount returns M suffix for millions`() {
+        assertEquals("1.0M", formatDownloadCount(1_000_000))
+        assertEquals("2.5M", formatDownloadCount(2_500_000))
+        assertEquals("100.0M", formatDownloadCount(100_000_000))
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/LocalModelsTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/LocalModelsTest.kt
@@ -1,0 +1,408 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.models.BulkPromoteRequest
+import com.artifactkeeper.android.data.models.BulkPromotionResponse
+import com.artifactkeeper.android.data.models.BulkPromotionResult
+import com.artifactkeeper.android.data.models.CveSummary
+import com.artifactkeeper.android.data.models.HealthCheck
+import com.artifactkeeper.android.data.models.LicenseSummary
+import com.artifactkeeper.android.data.models.LocalHealthResponse
+import com.artifactkeeper.android.data.models.PolicyStatus
+import com.artifactkeeper.android.data.models.PolicyViolation
+import com.artifactkeeper.android.data.models.PromoteArtifactRequest
+import com.artifactkeeper.android.data.models.PromotionHistoryEntry
+import com.artifactkeeper.android.data.models.PromotionResponse
+import com.artifactkeeper.android.data.models.RepositoryType
+import com.artifactkeeper.android.data.models.SavedServer
+import com.artifactkeeper.android.data.models.StagingArtifact
+import com.artifactkeeper.android.data.models.StagingRepository
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LocalModelsTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // =========================================================================
+    // SavedServer serialization
+    // =========================================================================
+
+    @Test
+    fun `SavedServer round-trip serialization`() {
+        val server = SavedServer(
+            id = "abc-123",
+            name = "Production",
+            url = "https://registry.example.com/",
+            addedAt = 1700000000000L
+        )
+        val encoded = json.encodeToString(server)
+        val decoded = json.decodeFromString<SavedServer>(encoded)
+        assertEquals(server, decoded)
+    }
+
+    @Test
+    fun `SavedServer deserialization from JSON string`() {
+        val jsonStr = """
+            {"id":"s1","name":"Dev","url":"http://localhost:8080/","addedAt":1234567890}
+        """.trimIndent()
+        val server = json.decodeFromString<SavedServer>(jsonStr)
+        assertEquals("s1", server.id)
+        assertEquals("Dev", server.name)
+        assertEquals("http://localhost:8080/", server.url)
+        assertEquals(1234567890L, server.addedAt)
+    }
+
+    // =========================================================================
+    // RepositoryType enum
+    // =========================================================================
+
+    @Test
+    fun `RepositoryType has all expected values`() {
+        val values = RepositoryType.entries
+        assertEquals(4, values.size)
+        assertTrue(values.contains(RepositoryType.LOCAL))
+        assertTrue(values.contains(RepositoryType.REMOTE))
+        assertTrue(values.contains(RepositoryType.VIRTUAL))
+        assertTrue(values.contains(RepositoryType.STAGING))
+    }
+
+    @Test
+    fun `RepositoryType fromString is case-insensitive`() {
+        assertEquals(RepositoryType.LOCAL, RepositoryType.fromString("local"))
+        assertEquals(RepositoryType.LOCAL, RepositoryType.fromString("LOCAL"))
+        assertEquals(RepositoryType.LOCAL, RepositoryType.fromString("Local"))
+        assertEquals(RepositoryType.REMOTE, RepositoryType.fromString("remote"))
+        assertEquals(RepositoryType.VIRTUAL, RepositoryType.fromString("virtual"))
+        assertEquals(RepositoryType.STAGING, RepositoryType.fromString("staging"))
+    }
+
+    @Test
+    fun `RepositoryType fromString defaults to LOCAL for unknown values`() {
+        assertEquals(RepositoryType.LOCAL, RepositoryType.fromString("unknown"))
+        assertEquals(RepositoryType.LOCAL, RepositoryType.fromString(""))
+    }
+
+    // =========================================================================
+    // PolicyStatus enum
+    // =========================================================================
+
+    @Test
+    fun `PolicyStatus has all expected values`() {
+        val values = PolicyStatus.entries
+        assertEquals(4, values.size)
+        assertTrue(values.contains(PolicyStatus.PASSING))
+        assertTrue(values.contains(PolicyStatus.FAILING))
+        assertTrue(values.contains(PolicyStatus.WARNING))
+        assertTrue(values.contains(PolicyStatus.PENDING))
+    }
+
+    @Test
+    fun `PolicyStatus fromString is case-insensitive`() {
+        assertEquals(PolicyStatus.PASSING, PolicyStatus.fromString("passing"))
+        assertEquals(PolicyStatus.PASSING, PolicyStatus.fromString("PASSING"))
+        assertEquals(PolicyStatus.FAILING, PolicyStatus.fromString("Failing"))
+        assertEquals(PolicyStatus.WARNING, PolicyStatus.fromString("warning"))
+        assertEquals(PolicyStatus.PENDING, PolicyStatus.fromString("pending"))
+    }
+
+    @Test
+    fun `PolicyStatus fromString defaults to PENDING for unknown values`() {
+        assertEquals(PolicyStatus.PENDING, PolicyStatus.fromString("unknown"))
+        assertEquals(PolicyStatus.PENDING, PolicyStatus.fromString(""))
+    }
+
+    // =========================================================================
+    // StagingArtifact defaults and serialization
+    // =========================================================================
+
+    @Test
+    fun `StagingArtifact has correct default values`() {
+        val artifact = StagingArtifact(
+            id = "a1",
+            name = "my-lib",
+            path = "/com/example/my-lib/1.0/my-lib-1.0.jar",
+            createdAt = "2024-01-01T00:00:00Z"
+        )
+        assertNull(artifact.repositoryKey)
+        assertNull(artifact.version)
+        assertNull(artifact.contentType)
+        assertEquals(0L, artifact.sizeBytes)
+        assertNull(artifact.checksumSha256)
+        assertEquals("pending", artifact.policyStatus)
+        assertNull(artifact.cveSummary)
+        assertNull(artifact.licenseSummary)
+        assertTrue(artifact.policyViolations.isEmpty())
+        assertTrue(artifact.canPromote)
+        assertNull(artifact.updatedAt)
+    }
+
+    @Test
+    fun `StagingArtifact full round-trip serialization`() {
+        val artifact = StagingArtifact(
+            id = "art-1",
+            repositoryKey = "staging-maven",
+            name = "my-lib",
+            path = "/com/example/my-lib/1.0/my-lib-1.0.jar",
+            version = "1.0.0",
+            contentType = "application/java-archive",
+            sizeBytes = 1024000,
+            checksumSha256 = "abc123def456",
+            policyStatus = "passing",
+            cveSummary = CveSummary(total = 3, criticalCount = 1, highCount = 2),
+            licenseSummary = LicenseSummary(total = 5, allowedCount = 4, deniedCount = 1, licenses = listOf("MIT", "GPL-3.0")),
+            policyViolations = listOf(
+                PolicyViolation(
+                    id = "v1",
+                    policyId = "p1",
+                    policyName = "No GPL",
+                    severity = "high",
+                    message = "GPL license detected"
+                )
+            ),
+            canPromote = false,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-02T00:00:00Z"
+        )
+        val encoded = json.encodeToString(artifact)
+        val decoded = json.decodeFromString<StagingArtifact>(encoded)
+        assertEquals(artifact, decoded)
+    }
+
+    @Test
+    fun `StagingArtifact deserialization with snake_case JSON`() {
+        val jsonStr = """
+            {
+                "id": "a2",
+                "repository_key": "staging-npm",
+                "name": "express",
+                "path": "/express/-/express-4.18.2.tgz",
+                "size_bytes": 2048,
+                "policy_status": "failing",
+                "can_promote": false,
+                "created_at": "2024-06-15T12:00:00Z"
+            }
+        """.trimIndent()
+        val artifact = json.decodeFromString<StagingArtifact>(jsonStr)
+        assertEquals("a2", artifact.id)
+        assertEquals("staging-npm", artifact.repositoryKey)
+        assertEquals(2048L, artifact.sizeBytes)
+        assertEquals("failing", artifact.policyStatus)
+        assertFalse(artifact.canPromote)
+    }
+
+    // =========================================================================
+    // StagingRepository defaults and serialization
+    // =========================================================================
+
+    @Test
+    fun `StagingRepository has correct default values`() {
+        val repo = StagingRepository(
+            id = "r1",
+            key = "staging-maven",
+            name = "Staging Maven",
+            format = "maven",
+            createdAt = "2024-01-01T00:00:00Z"
+        )
+        assertEquals("staging", repo.repoType)
+        assertFalse(repo.isPublic)
+        assertNull(repo.description)
+        assertEquals(0L, repo.storageUsedBytes)
+        assertEquals(0, repo.artifactCount)
+        assertEquals(0, repo.pendingCount)
+        assertEquals(0, repo.passingCount)
+        assertEquals(0, repo.failingCount)
+        assertNull(repo.targetRepositoryKey)
+        assertNull(repo.updatedAt)
+    }
+
+    @Test
+    fun `StagingRepository round-trip serialization`() {
+        val repo = StagingRepository(
+            id = "r2",
+            key = "staging-npm",
+            name = "Staging NPM",
+            format = "npm",
+            repoType = "staging",
+            isPublic = false,
+            description = "NPM staging area",
+            storageUsedBytes = 50_000_000,
+            artifactCount = 120,
+            pendingCount = 10,
+            passingCount = 100,
+            failingCount = 10,
+            targetRepositoryKey = "npm-releases",
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-06-15T00:00:00Z"
+        )
+        val encoded = json.encodeToString(repo)
+        val decoded = json.decodeFromString<StagingRepository>(encoded)
+        assertEquals(repo, decoded)
+    }
+
+    // =========================================================================
+    // PromotionHistoryEntry serialization
+    // =========================================================================
+
+    @Test
+    fun `PromotionHistoryEntry has correct defaults`() {
+        val entry = PromotionHistoryEntry(
+            id = "ph1",
+            artifactId = "a1",
+            sourceRepositoryKey = "staging-maven",
+            targetRepositoryKey = "maven-releases",
+            promotedAt = "2024-06-15T12:00:00Z"
+        )
+        assertNull(entry.artifactName)
+        assertNull(entry.artifactVersion)
+        assertNull(entry.promotedBy)
+        assertNull(entry.promotedByUsername)
+        assertNull(entry.comment)
+        assertFalse(entry.forced)
+    }
+
+    @Test
+    fun `PromotionHistoryEntry round-trip serialization`() {
+        val entry = PromotionHistoryEntry(
+            id = "ph2",
+            artifactId = "a2",
+            artifactName = "react",
+            artifactVersion = "18.2.0",
+            sourceRepositoryKey = "staging-npm",
+            targetRepositoryKey = "npm-releases",
+            promotedBy = "user-123",
+            promotedByUsername = "admin",
+            comment = "Approved by QA",
+            forced = true,
+            promotedAt = "2024-06-15T12:00:00Z"
+        )
+        val encoded = json.encodeToString(entry)
+        val decoded = json.decodeFromString<PromotionHistoryEntry>(encoded)
+        assertEquals(entry, decoded)
+    }
+
+    // =========================================================================
+    // CveSummary defaults
+    // =========================================================================
+
+    @Test
+    fun `CveSummary has zero defaults`() {
+        val summary = CveSummary()
+        assertEquals(0, summary.total)
+        assertEquals(0, summary.criticalCount)
+        assertEquals(0, summary.highCount)
+        assertEquals(0, summary.mediumCount)
+        assertEquals(0, summary.lowCount)
+    }
+
+    // =========================================================================
+    // LicenseSummary defaults
+    // =========================================================================
+
+    @Test
+    fun `LicenseSummary has zero defaults and empty licenses`() {
+        val summary = LicenseSummary()
+        assertEquals(0, summary.total)
+        assertEquals(0, summary.allowedCount)
+        assertEquals(0, summary.deniedCount)
+        assertEquals(0, summary.unknownCount)
+        assertTrue(summary.licenses.isEmpty())
+    }
+
+    // =========================================================================
+    // PromoteArtifactRequest serialization
+    // =========================================================================
+
+    @Test
+    fun `PromoteArtifactRequest defaults and serialization`() {
+        val request = PromoteArtifactRequest(targetRepositoryKey = "maven-releases")
+        assertFalse(request.force)
+        assertNull(request.comment)
+
+        val encoded = json.encodeToString(request)
+        val decoded = json.decodeFromString<PromoteArtifactRequest>(encoded)
+        assertEquals(request, decoded)
+    }
+
+    // =========================================================================
+    // BulkPromoteRequest and BulkPromotionResponse serialization
+    // =========================================================================
+
+    @Test
+    fun `BulkPromoteRequest round-trip serialization`() {
+        val request = BulkPromoteRequest(
+            artifactIds = listOf("a1", "a2", "a3"),
+            targetRepositoryKey = "npm-releases",
+            force = true,
+            comment = "Batch promotion"
+        )
+        val encoded = json.encodeToString(request)
+        val decoded = json.decodeFromString<BulkPromoteRequest>(encoded)
+        assertEquals(request, decoded)
+    }
+
+    @Test
+    fun `BulkPromotionResponse round-trip serialization`() {
+        val response = BulkPromotionResponse(
+            totalRequested = 3,
+            totalSucceeded = 2,
+            totalFailed = 1,
+            results = listOf(
+                BulkPromotionResult(artifactId = "a1", success = true, message = "ok"),
+                BulkPromotionResult(artifactId = "a2", success = true, message = "ok"),
+                BulkPromotionResult(artifactId = "a3", success = false, error = "Policy violation"),
+            )
+        )
+        val encoded = json.encodeToString(response)
+        val decoded = json.decodeFromString<BulkPromotionResponse>(encoded)
+        assertEquals(response, decoded)
+    }
+
+    // =========================================================================
+    // LocalHealthResponse serialization
+    // =========================================================================
+
+    @Test
+    fun `LocalHealthResponse round-trip serialization`() {
+        val health = LocalHealthResponse(
+            status = "healthy",
+            checks = mapOf(
+                "database" to HealthCheck(status = "up", responseTimeMs = 12),
+                "storage" to HealthCheck(status = "up", responseTimeMs = 5),
+            )
+        )
+        val encoded = json.encodeToString(health)
+        val decoded = json.decodeFromString<LocalHealthResponse>(encoded)
+        assertEquals(health, decoded)
+    }
+
+    @Test
+    fun `LocalHealthResponse defaults to empty checks`() {
+        val jsonStr = """{"status":"healthy"}"""
+        val health = json.decodeFromString<LocalHealthResponse>(jsonStr)
+        assertEquals("healthy", health.status)
+        assertTrue(health.checks.isEmpty())
+    }
+
+    // =========================================================================
+    // PromotionResponse serialization
+    // =========================================================================
+
+    @Test
+    fun `PromotionResponse round-trip serialization`() {
+        val response = PromotionResponse(
+            success = true,
+            message = "Promoted successfully",
+            artifactId = "a1",
+            targetRepositoryKey = "maven-releases",
+            promotedAt = "2024-06-15T12:00:00Z"
+        )
+        val encoded = json.encodeToString(response)
+        val decoded = json.decodeFromString<PromotionResponse>(encoded)
+        assertEquals(response, decoded)
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/StagingViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/StagingViewModelTest.kt
@@ -1,0 +1,267 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.models.PolicyStatus
+import com.artifactkeeper.android.data.models.StagingArtifact
+import com.artifactkeeper.android.data.models.StagingRepository
+import com.artifactkeeper.android.ui.screens.staging.StagingUiState
+import com.artifactkeeper.android.ui.screens.staging.StagingViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StagingViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var viewModel: StagingViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = StagingViewModel()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // =========================================================================
+    // Initial state
+    // =========================================================================
+
+    @Test
+    fun `initial state has empty collections and no loading flags`() {
+        val state = viewModel.uiState.value
+        assertEquals(StagingUiState(), state)
+        assertTrue(state.stagingRepos.isEmpty())
+        assertNull(state.selectedRepo)
+        assertTrue(state.artifacts.isEmpty())
+        assertTrue(state.selectedArtifactIds.isEmpty())
+        assertTrue(state.promotionHistory.isEmpty())
+        assertTrue(state.targetRepositories.isEmpty())
+        assertFalse(state.isLoadingRepos)
+        assertFalse(state.isLoadingArtifacts)
+        assertFalse(state.isLoadingHistory)
+        assertFalse(state.isPromoting)
+        assertNull(state.reposError)
+        assertNull(state.artifactsError)
+        assertNull(state.historyError)
+        assertNull(state.promotionError)
+        assertNull(state.promotionSuccess)
+        assertNull(state.filterStatus)
+    }
+
+    // =========================================================================
+    // selectRepo / clearSelectedRepo
+    // =========================================================================
+
+    @Test
+    fun `selectRepo sets selectedRepo and clears artifacts and selection`() {
+        val repo = makeStagingRepo("staging-maven")
+
+        // Pre-populate some state to verify it gets cleared
+        viewModel.uiState.value.let { /* initial state */ }
+
+        viewModel.selectRepo(repo)
+
+        val state = viewModel.uiState.value
+        assertEquals(repo, state.selectedRepo)
+        // artifacts and selection should be cleared when selecting a new repo
+        assertTrue(state.selectedArtifactIds.isEmpty())
+        assertTrue(state.promotionHistory.isEmpty())
+    }
+
+    @Test
+    fun `clearSelectedRepo resets repo-specific state`() {
+        val repo = makeStagingRepo("staging-npm")
+        viewModel.selectRepo(repo)
+
+        viewModel.clearSelectedRepo()
+
+        val state = viewModel.uiState.value
+        assertNull(state.selectedRepo)
+        assertTrue(state.artifacts.isEmpty())
+        assertTrue(state.selectedArtifactIds.isEmpty())
+        assertTrue(state.promotionHistory.isEmpty())
+    }
+
+    // =========================================================================
+    // toggleArtifactSelection
+    // =========================================================================
+
+    @Test
+    fun `toggleArtifactSelection adds artifact to selection`() {
+        viewModel.toggleArtifactSelection("a1")
+        assertTrue(viewModel.uiState.value.selectedArtifactIds.contains("a1"))
+    }
+
+    @Test
+    fun `toggleArtifactSelection removes artifact if already selected`() {
+        viewModel.toggleArtifactSelection("a1")
+        viewModel.toggleArtifactSelection("a1")
+        assertFalse(viewModel.uiState.value.selectedArtifactIds.contains("a1"))
+    }
+
+    @Test
+    fun `toggleArtifactSelection handles multiple artifacts`() {
+        viewModel.toggleArtifactSelection("a1")
+        viewModel.toggleArtifactSelection("a2")
+        viewModel.toggleArtifactSelection("a3")
+
+        val selected = viewModel.uiState.value.selectedArtifactIds
+        assertEquals(3, selected.size)
+        assertTrue(selected.containsAll(listOf("a1", "a2", "a3")))
+
+        // Remove one
+        viewModel.toggleArtifactSelection("a2")
+        val updated = viewModel.uiState.value.selectedArtifactIds
+        assertEquals(2, updated.size)
+        assertFalse(updated.contains("a2"))
+    }
+
+    // =========================================================================
+    // clearSelection
+    // =========================================================================
+
+    @Test
+    fun `clearSelection empties the selection set`() {
+        viewModel.toggleArtifactSelection("a1")
+        viewModel.toggleArtifactSelection("a2")
+        assertEquals(2, viewModel.uiState.value.selectedArtifactIds.size)
+
+        viewModel.clearSelection()
+        assertTrue(viewModel.uiState.value.selectedArtifactIds.isEmpty())
+    }
+
+    // =========================================================================
+    // setFilterStatus
+    // =========================================================================
+
+    @Test
+    fun `setFilterStatus updates filter and clears selection`() {
+        viewModel.toggleArtifactSelection("a1")
+        viewModel.setFilterStatus(PolicyStatus.PASSING)
+
+        val state = viewModel.uiState.value
+        assertEquals(PolicyStatus.PASSING, state.filterStatus)
+        assertTrue(state.selectedArtifactIds.isEmpty())
+    }
+
+    @Test
+    fun `setFilterStatus to null clears the filter`() {
+        viewModel.setFilterStatus(PolicyStatus.FAILING)
+        viewModel.setFilterStatus(null)
+        assertNull(viewModel.uiState.value.filterStatus)
+    }
+
+    // =========================================================================
+    // clearMessages
+    // =========================================================================
+
+    @Test
+    fun `clearMessages resets promotion error and success`() {
+        // We cannot easily set promotionError/promotionSuccess without API calls,
+        // but we can verify clearMessages works on a clean state (no-op).
+        viewModel.clearMessages()
+        val state = viewModel.uiState.value
+        assertNull(state.promotionError)
+        assertNull(state.promotionSuccess)
+    }
+
+    // =========================================================================
+    // promoteBulk with no selection
+    // =========================================================================
+
+    @Test
+    fun `promoteBulk calls onError when no artifacts selected`() {
+        val repo = makeStagingRepo("staging-maven")
+        viewModel.selectRepo(repo)
+        viewModel.clearSelection()
+
+        var errorMsg: String? = null
+        viewModel.promoteBulk(
+            targetRepoKey = "maven-releases",
+            onError = { errorMsg = it }
+        )
+
+        assertEquals("No artifacts selected", errorMsg)
+    }
+
+    @Test
+    fun `promoteBulk does nothing when no repo selected`() {
+        // No repo selected, so promoteBulk should return immediately
+        viewModel.toggleArtifactSelection("a1")
+
+        var errorCalled = false
+        var successCalled = false
+        viewModel.promoteBulk(
+            targetRepoKey = "maven-releases",
+            onError = { errorCalled = true },
+            onSuccess = { successCalled = true }
+        )
+
+        // Neither callback should be called because the method returns early
+        assertFalse(errorCalled)
+        assertFalse(successCalled)
+    }
+
+    // =========================================================================
+    // promoteArtifact with no repo selected
+    // =========================================================================
+
+    @Test
+    fun `promoteArtifact does nothing when no repo selected`() {
+        var errorCalled = false
+        var successCalled = false
+        viewModel.promoteArtifact(
+            artifactId = "a1",
+            targetRepoKey = "maven-releases",
+            onError = { errorCalled = true },
+            onSuccess = { successCalled = true }
+        )
+
+        assertFalse(errorCalled)
+        assertFalse(successCalled)
+        assertFalse(viewModel.uiState.value.isPromoting)
+    }
+
+    // =========================================================================
+    // StagingUiState data class behavior
+    // =========================================================================
+
+    @Test
+    fun `StagingUiState copy preserves unmodified fields`() {
+        val original = StagingUiState(
+            isLoadingRepos = true,
+            reposError = "network error",
+            filterStatus = PolicyStatus.WARNING,
+        )
+        val copied = original.copy(isLoadingRepos = false)
+
+        assertFalse(copied.isLoadingRepos)
+        assertEquals("network error", copied.reposError)
+        assertEquals(PolicyStatus.WARNING, copied.filterStatus)
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun makeStagingRepo(key: String) = StagingRepository(
+        id = "repo-$key",
+        key = key,
+        name = "Staging ${key.substringAfter("-")}",
+        format = key.substringAfter("-"),
+        createdAt = "2024-01-01T00:00:00Z"
+    )
+}

--- a/app/src/test/java/com/artifactkeeper/android/VirtualMembersViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/VirtualMembersViewModelTest.kt
@@ -1,0 +1,106 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.ui.screens.repositories.VirtualMembersUiState
+import com.artifactkeeper.android.ui.screens.repositories.VirtualMembersViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class VirtualMembersViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var viewModel: VirtualMembersViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = VirtualMembersViewModel()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // =========================================================================
+    // Initial state
+    // =========================================================================
+
+    @Test
+    fun `initial state has empty collections and no loading flags`() {
+        val state = viewModel.uiState.value
+        assertEquals(VirtualMembersUiState(), state)
+        assertTrue(state.members.isEmpty())
+        assertTrue(state.eligibleRepos.isEmpty())
+        assertFalse(state.isLoading)
+        assertFalse(state.isLoadingEligible)
+        assertFalse(state.isSaving)
+        assertNull(state.error)
+        assertNull(state.successMessage)
+    }
+
+    // =========================================================================
+    // clearMessages
+    // =========================================================================
+
+    @Test
+    fun `clearMessages resets error and successMessage`() {
+        viewModel.clearMessages()
+        val state = viewModel.uiState.value
+        assertNull(state.error)
+        assertNull(state.successMessage)
+    }
+
+    // =========================================================================
+    // VirtualMembersUiState data class
+    // =========================================================================
+
+    @Test
+    fun `VirtualMembersUiState copy preserves unmodified fields`() {
+        val original = VirtualMembersUiState(
+            isLoading = true,
+            error = "something failed",
+            isSaving = true,
+        )
+        val copied = original.copy(isLoading = false)
+
+        assertFalse(copied.isLoading)
+        assertEquals("something failed", copied.error)
+        assertTrue(copied.isSaving)
+    }
+
+    @Test
+    fun `VirtualMembersUiState default equality`() {
+        val a = VirtualMembersUiState()
+        val b = VirtualMembersUiState()
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `VirtualMembersUiState with all fields set`() {
+        val state = VirtualMembersUiState(
+            members = emptyList(),
+            eligibleRepos = emptyList(),
+            isLoading = true,
+            isLoadingEligible = true,
+            isSaving = true,
+            error = "error",
+            successMessage = "success",
+        )
+        assertTrue(state.isLoading)
+        assertTrue(state.isLoadingEligible)
+        assertTrue(state.isSaving)
+        assertEquals("error", state.error)
+        assertEquals("success", state.successMessage)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds test dependencies: kotlinx-coroutines-test, MockK, and Turbine to app/build.gradle.kts
- Adds 77 unit tests across 5 test classes covering formatting utilities (formatBytes, formatDuration, formatRelativeTime, formatDownloadCount), data model serialization and default values (SavedServer, StagingArtifact, StagingRepository, PromotionHistoryEntry, CveSummary, LicenseSummary, and more), ViewModel state management (StagingViewModel selection, filtering, bulk promote guards; VirtualMembersViewModel initial state), and ApiClient configuration logic (configure, clearConfig, setToken, URL trailing slash normalization)
- All tests run as local JVM unit tests via ./gradlew app:testDebugUnitTest with no Android device or emulator required

## Test plan
- [x] All 77 tests pass locally with `./gradlew app:testDebugUnitTest`
- [x] No changes to production code
- [x] SDK module is untouched