### PR TITLE
Add SonarCloud scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,11 @@ jobs:
       - name: Run tests
         run: ./gradlew test
 
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   nightly:
     name: Nightly Release
     runs-on: ubuntu-latest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=artifact-keeper_artifact-keeper-android
+sonar.organization=artifact-keeper
+sonar.sources=app/src/main
+sonar.tests=app/src/test,app/src/androidTest
+sonar.exclusions=**/build/**,**/.gradle/**
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Add `sonar-project.properties` with project key, organization, source/test paths, and build exclusions.
- Add a SonarCloud scan step to the test job in CI so analysis runs after unit tests on every push and PR.

## Test plan
- [ ] Verify the `SONAR_TOKEN` secret is configured in the repository settings.
- [ ] Confirm the SonarCloud scan step runs successfully after tests in a CI run.
- [ ] Check that the SonarCloud dashboard shows results for the `artifact-keeper_artifact-keeper-android` project.