### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,113 @@
+name: Bug Report
+description: Report a bug or unexpected behavior in the Artifact Keeper Android app
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        If this is a **backend or API** issue, please file it in [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new).
+        If this is a **web UI** issue, please file it in [artifact-keeper-web](https://github.com/artifact-keeper/artifact-keeper-web/issues/new).
+        If you're unsure where the problem lives, go ahead and file it here and we'll move it to the right place.
+
+        For security vulnerabilities, please use [private security reporting](https://github.com/artifact-keeper/artifact-keeper-android/security/advisories/new) instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear summary of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: Fill in the details about your device and environment.
+      value: |
+        - Device: (e.g., Pixel 9, Samsung Galaxy S25)
+        - Android Version: (e.g., 15, 14)
+        - App Version:
+        - RAM:
+        - Network conditions: (e.g., Wi-Fi, cellular, VPN)
+    validations:
+      required: true
+
+  - type: input
+    id: backend-version
+    attributes:
+      label: Backend Version
+      description: The version of the Artifact Keeper backend, if known.
+      placeholder: "e.g., 1.1.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the issue.
+      placeholder: |
+        1. Open the app
+        2. Navigate to ...
+        3. Tap on ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logcat-output
+    attributes:
+      label: Logcat Output
+      description: |
+        Relevant logcat output, if available.
+        Tip: Filter logcat with `adb logcat -s ArtifactKeeper` for relevant logs.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or Screen Recording
+      description: Attach screenshots or a screen recording that demonstrates the issue.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other information that might help us investigate.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this has not already been reported.
+          required: true
+        - label: I have redacted any sensitive information (tokens, passwords, internal URLs).
+          required: true
+        - label: I am using a supported version of the app.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Backend / API Issues
+    url: https://github.com/artifact-keeper/artifact-keeper/issues/new
+    about: Report bugs or request features for the backend API and server
+  - name: Web UI Issues
+    url: https://github.com/artifact-keeper/artifact-keeper-web/issues/new
+    about: Report bugs or request features for the web frontend
+  - name: Security Vulnerability
+    url: https://github.com/artifact-keeper/artifact-keeper-android/security/advisories/new
+    about: Please report security vulnerabilities privately through GitHub Security Advisories
+  - name: GitHub Discussions
+    url: https://github.com/orgs/artifact-keeper/discussions
+    about: Ask questions and discuss ideas with the community
+  - name: Documentation
+    url: https://artifactkeeper.com/docs
+    about: Browse the official documentation

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,58 @@
+name: Documentation Issue
+description: Report an issue with documentation or suggest improvements
+labels: ["documentation", "needs-triage"]
+body:
+  - type: dropdown
+    id: documentation-type
+    attributes:
+      label: Documentation Type
+      description: What kind of documentation issue is this?
+      options:
+        - Missing documentation
+        - Incorrect or outdated information
+        - Unclear or confusing content
+        - Typo or formatting issue
+        - Missing examples
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Where is the documentation issue? Provide a URL, file path, or section name.
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the documentation issue in detail.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-improvement
+    attributes:
+      label: Suggested Improvement
+      description: How would you improve this documentation?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other information that might be helpful.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this has not already been reported.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,79 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for the Artifact Keeper Android app
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature.
+
+        If this is a **backend or API** feature request, please file it in [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new).
+        If you're unsure whether the change belongs in the app or the backend, go ahead and file it here and we'll move it to the right place.
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: Describe the problem or limitation you're running into.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe how you'd like this to work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative approaches you've thought about.
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Describe the specific scenario where this feature would be useful.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the app does this relate to?
+      options:
+        - Artifacts Browser
+        - Integration
+        - Security / Scanning
+        - Operations
+        - Administration
+        - Notifications
+        - Widgets
+        - Material Design / UI
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other information, mockups, or references that might be helpful.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this has not already been requested.
+          required: true
+        - label: I have reviewed the documentation to confirm this feature does not already exist.
+          required: true


### PR DESCRIPTION
## Summary

- Add GitHub issue form templates for bug reports, feature requests, and documentation issues
- Bug report template includes Android-specific fields: device model, Android version, logcat output, and network conditions
- Feature request template includes a component dropdown covering all app sections (Artifacts Browser, Integration, Security, Operations, etc.)
- Documentation template includes a type dropdown for categorizing the documentation issue
- All templates include a pre-submission checklist with required items
- Add config.yml with contact links directing users to the correct repo for backend, web, and security issues, plus links to GitHub Discussions and documentation

## Test plan

- [ ] Navigate to https://github.com/artifact-keeper/artifact-keeper-android/issues/new/choose and verify all three templates appear
- [ ] Verify the contact links section renders correctly with links to backend, web, security advisories, discussions, and docs
- [ ] Open each template form and confirm all fields render, required fields are enforced, and dropdowns populate correctly
- [ ] Confirm the bug report environment info field is pre-filled with the placeholder template
- [ ] Confirm the logcat output field renders with shell syntax highlighting
- [ ] Verify blank issues are still allowed