### PR TITLE
fix(security): move HTTP logging inside DEBUG, disable cleartext traffic

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -69,11 +69,11 @@ object ApiClient {
 
     private fun buildOkHttpClientBuilder(): OkHttpClient.Builder {
         val builder = OkHttpClient.Builder()
-            .addInterceptor(HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
-            })
 
         if (BuildConfig.DEBUG) {
+            builder.addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            })
             val trustAllManager = object : X509TrustManager {
                 override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {}
                 override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {}

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -6,10 +6,13 @@
             <certificates src="system" />
         </trust-anchors>
     </debug-overrides>
-    <!-- Allow cleartext HTTP for self-hosted servers (user explicitly enters http://) -->
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>
     </base-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- Move `HttpLoggingInterceptor.Level.BODY` inside `BuildConfig.DEBUG` block so release builds don't log auth tokens
- Set `cleartextTrafficPermitted=false` globally in network_security_config.xml
- Scope cleartext exception to localhost and 10.0.2.2 (emulator) only

## Test plan
- [ ] Debug build still logs HTTP bodies
- [ ] Release build does not log HTTP bodies
- [ ] App connects to HTTPS servers normally
- [ ] Dev builds can still connect to localhost HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)