### PR TITLE
fix: migrate promotion to 1.2.1 promotion API with body mapping

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/staging/PromotionMapper.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/staging/PromotionMapper.kt
@@ -1,0 +1,122 @@
+package com.artifactkeeper.android.ui.screens.staging
+
+import com.artifactkeeper.android.data.models.BulkPromoteRequest
+import com.artifactkeeper.android.data.models.BulkPromotionResponse
+import com.artifactkeeper.android.data.models.BulkPromotionResult
+import com.artifactkeeper.android.data.models.PromoteArtifactRequest
+import com.artifactkeeper.android.data.models.PromotionHistoryEntry
+import com.artifactkeeper.android.data.models.PromotionResponse
+import java.util.UUID
+
+/**
+ * Maps between the app's local staging/promotion UI models and the generated
+ * 1.2.1 SDK promotion models. The 1.2.1 backend dropped the staging endpoints
+ * under api/v1/staging; promotion now lives under api/v1/promotion with a
+ * different request and response shape. This object keeps the UI contract
+ * stable while routing traffic to the supported SDK operations.
+ */
+object PromotionMapper {
+
+    /**
+     * Build the SDK promote-artifact request from the local UI request.
+     * The local "force" flag maps to the SDK skip_policy_check flag and the
+     * local "comment" maps to SDK notes. Target repository key carries over.
+     */
+    fun toSdkPromoteRequest(
+        request: PromoteArtifactRequest,
+    ): com.artifactkeeper.client.models.PromoteArtifactRequest =
+        com.artifactkeeper.client.models.PromoteArtifactRequest(
+            targetRepository = request.targetRepositoryKey,
+            skipPolicyCheck = request.force,
+            notes = request.comment,
+        )
+
+    /**
+     * Build the SDK bulk-promote request. Artifact ids are UUIDs in 1.2.1;
+     * any id that is not a valid UUID is dropped rather than crashing the call.
+     */
+    fun toSdkBulkRequest(
+        request: BulkPromoteRequest,
+    ): com.artifactkeeper.client.models.BulkPromoteRequest =
+        com.artifactkeeper.client.models.BulkPromoteRequest(
+            artifactIds = request.artifactIds.mapNotNull { it.toUuidOrNull() },
+            targetRepository = request.targetRepositoryKey,
+            skipPolicyCheck = request.force,
+            notes = request.comment,
+        )
+
+    /**
+     * Map a single SDK promotion result back to the local UI response.
+     */
+    fun toLocalPromotionResponse(
+        sdk: com.artifactkeeper.client.models.PromotionResponse,
+        artifactId: String,
+    ): PromotionResponse =
+        PromotionResponse(
+            success = sdk.promoted,
+            message = sdk.message ?: defaultPromotionMessage(sdk),
+            artifactId = artifactId,
+            targetRepositoryKey = sdk.target,
+            promotedAt = null,
+        )
+
+    /**
+     * Map an SDK bulk promotion response back to the local UI response. The SDK
+     * reports total/promoted/failed counts and per-artifact results; the local
+     * model wants total_requested/total_succeeded/total_failed plus results.
+     */
+    fun toLocalBulkResponse(
+        sdk: com.artifactkeeper.client.models.BulkPromotionResponse,
+    ): BulkPromotionResponse =
+        BulkPromotionResponse(
+            totalRequested = sdk.total,
+            totalSucceeded = sdk.promoted,
+            totalFailed = sdk.failed,
+            results = sdk.results.map { result ->
+                BulkPromotionResult(
+                    artifactId = result.target,
+                    success = result.promoted,
+                    message = result.message,
+                    error = if (!result.promoted) result.message else null,
+                )
+            },
+        )
+
+    /**
+     * Map an SDK promotion history entry to the local UI entry. The SDK exposes
+     * an artifact path rather than a name/version pair, so the trailing path
+     * segment becomes the display name and version is left absent.
+     */
+    fun toLocalHistoryEntry(
+        sdk: com.artifactkeeper.client.models.PromotionHistoryEntry,
+    ): PromotionHistoryEntry =
+        PromotionHistoryEntry(
+            id = sdk.id.toString(),
+            artifactId = sdk.artifactId.toString(),
+            artifactName = sdk.artifactPath.substringAfterLast('/'),
+            artifactVersion = null,
+            sourceRepositoryKey = sdk.sourceRepoKey,
+            targetRepositoryKey = sdk.targetRepoKey,
+            promotedBy = sdk.promotedBy?.toString(),
+            promotedByUsername = sdk.promotedByUsername,
+            comment = sdk.notes,
+            forced = false,
+            promotedAt = sdk.createdAt.toString(),
+        )
+
+    private fun defaultPromotionMessage(
+        sdk: com.artifactkeeper.client.models.PromotionResponse,
+    ): String =
+        if (sdk.promoted) {
+            "Promoted to ${sdk.target}"
+        } else {
+            "Promotion blocked by ${sdk.policyViolations.size} policy violation(s)"
+        }
+
+    private fun String.toUuidOrNull(): UUID? =
+        try {
+            UUID.fromString(this)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/staging/StagingViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/staging/StagingViewModel.kt
@@ -121,8 +121,9 @@ class StagingViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoadingHistory = true, historyError = null) }
             try {
-                val response = ApiClient.stagingApi.getPromotionHistory(repoKey).unwrap()
-                _uiState.update { it.copy(promotionHistory = response.items, isLoadingHistory = false) }
+                val response = ApiClient.promotionApi.promotionHistory(repoKey).unwrap()
+                val history = response.items.map { PromotionMapper.toLocalHistoryEntry(it) }
+                _uiState.update { it.copy(promotionHistory = history, isLoadingHistory = false) }
             } catch (e: Exception) {
                 _uiState.update {
                     it.copy(
@@ -190,7 +191,12 @@ class StagingViewModel @Inject constructor(
                     force = force,
                     comment = comment,
                 )
-                val response = ApiClient.stagingApi.promoteArtifact(repoKey, artifactId, request).unwrap()
+                val sdkResponse = ApiClient.promotionApi.promoteArtifact(
+                    key = repoKey,
+                    artifactId = java.util.UUID.fromString(artifactId),
+                    promoteArtifactRequest = PromotionMapper.toSdkPromoteRequest(request),
+                ).unwrap()
+                val response = PromotionMapper.toLocalPromotionResponse(sdkResponse, artifactId)
                 _uiState.update {
                     it.copy(
                         isPromoting = false,
@@ -233,7 +239,11 @@ class StagingViewModel @Inject constructor(
                     force = force,
                     comment = comment,
                 )
-                val response = ApiClient.stagingApi.promoteBulk(repoKey, request).unwrap()
+                val sdkResponse = ApiClient.promotionApi.promoteArtifactsBulk(
+                    key = repoKey,
+                    bulkPromoteRequest = PromotionMapper.toSdkBulkRequest(request),
+                ).unwrap()
+                val response = PromotionMapper.toLocalBulkResponse(sdkResponse)
                 _uiState.update {
                     it.copy(
                         isPromoting = false,

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/staging/StagingViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/staging/StagingViewModel.kt
@@ -52,6 +52,9 @@ class StagingViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoadingRepos = true, reposError = null) }
             try {
+                // TODO(#81): api/v1/staging/repositories was removed in 1.2.1 and has no
+                // direct replacement. Redesign to discover staging repos via list_repositories
+                // (filtered by repo type) as part of the Staging section wave.
                 val response = ApiClient.stagingApi.listStagingRepos().unwrap()
                 _uiState.update { it.copy(stagingRepos = response.items, isLoadingRepos = false) }
             } catch (e: Exception) {
@@ -94,6 +97,10 @@ class StagingViewModel @Inject constructor(
             _uiState.update { it.copy(isLoadingArtifacts = true, artifactsError = null) }
             try {
                 val statusFilter = _uiState.value.filterStatus?.name?.lowercase()
+                // TODO(#81): api/v1/staging/repositories/{key}/artifacts was removed in 1.2.1
+                // and has no direct replacement (no per-artifact policy-status staging listing).
+                // Redesign to discover staging artifacts via list_artifacts as part of the
+                // Staging section wave.
                 val response = ApiClient.stagingApi.listStagingArtifacts(
                     repoKey = repoKey,
                     policyStatus = statusFilter,

--- a/app/src/test/java/com/artifactkeeper/android/PromotionMapperTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/PromotionMapperTest.kt
@@ -1,0 +1,158 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.models.BulkPromoteRequest
+import com.artifactkeeper.android.data.models.PromoteArtifactRequest
+import com.artifactkeeper.android.ui.screens.staging.PromotionMapper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.OffsetDateTime
+import java.util.UUID
+
+/**
+ * Regression coverage for the 1.2.1 staging-to-promotion routing. These tests
+ * pin the field mapping between the app's local staging models and the SDK's
+ * promotion models (under api/v1/promotion) so the UI contract stays stable.
+ */
+class PromotionMapperTest {
+
+    @Test
+    fun `toSdkPromoteRequest maps force to skip policy check and comment to notes`() {
+        val local = PromoteArtifactRequest(
+            targetRepositoryKey = "maven-releases",
+            force = true,
+            comment = "ship it",
+        )
+
+        val sdk = PromotionMapper.toSdkPromoteRequest(local)
+
+        assertEquals("maven-releases", sdk.targetRepository)
+        assertEquals(true, sdk.skipPolicyCheck)
+        assertEquals("ship it", sdk.notes)
+    }
+
+    @Test
+    fun `toSdkBulkRequest converts string ids to uuids and drops invalid ids`() {
+        val good = UUID.randomUUID().toString()
+        val local = BulkPromoteRequest(
+            artifactIds = listOf(good, "not-a-uuid"),
+            targetRepositoryKey = "npm-releases",
+            force = false,
+            comment = null,
+        )
+
+        val sdk = PromotionMapper.toSdkBulkRequest(local)
+
+        assertEquals(1, sdk.artifactIds.size)
+        assertEquals(UUID.fromString(good), sdk.artifactIds.first())
+        assertEquals("npm-releases", sdk.targetRepository)
+        assertEquals(false, sdk.skipPolicyCheck)
+        assertNull(sdk.notes)
+    }
+
+    @Test
+    fun `toLocalPromotionResponse carries over promoted flag target and message`() {
+        val sdk = com.artifactkeeper.client.models.PromotionResponse(
+            policyViolations = emptyList(),
+            promoted = true,
+            source = "maven-staging",
+            target = "maven-releases",
+            message = "Promoted",
+            promotionId = UUID.randomUUID(),
+        )
+
+        val local = PromotionMapper.toLocalPromotionResponse(sdk, artifactId = "art-1")
+
+        assertTrue(local.success)
+        assertEquals("Promoted", local.message)
+        assertEquals("art-1", local.artifactId)
+        assertEquals("maven-releases", local.targetRepositoryKey)
+    }
+
+    @Test
+    fun `toLocalPromotionResponse synthesizes a message when the SDK omits one`() {
+        val sdk = com.artifactkeeper.client.models.PromotionResponse(
+            policyViolations = emptyList(),
+            promoted = true,
+            source = "maven-staging",
+            target = "maven-releases",
+            message = null,
+            promotionId = null,
+        )
+
+        val local = PromotionMapper.toLocalPromotionResponse(sdk, artifactId = "art-1")
+
+        assertEquals("Promoted to maven-releases", local.message)
+    }
+
+    @Test
+    fun `toLocalBulkResponse maps counts and per-artifact results`() {
+        val sdk = com.artifactkeeper.client.models.BulkPromotionResponse(
+            failed = 1,
+            promoted = 2,
+            total = 3,
+            results = listOf(
+                com.artifactkeeper.client.models.PromotionResponse(
+                    policyViolations = emptyList(),
+                    promoted = true,
+                    source = "s",
+                    target = "art-a",
+                    message = "ok",
+                ),
+                com.artifactkeeper.client.models.PromotionResponse(
+                    policyViolations = emptyList(),
+                    promoted = false,
+                    source = "s",
+                    target = "art-b",
+                    message = "blocked",
+                ),
+            ),
+        )
+
+        val local = PromotionMapper.toLocalBulkResponse(sdk)
+
+        assertEquals(3, local.totalRequested)
+        assertEquals(2, local.totalSucceeded)
+        assertEquals(1, local.totalFailed)
+        assertEquals(2, local.results.size)
+        assertTrue(local.results[0].success)
+        assertNull(local.results[0].error)
+        assertFalse(local.results[1].success)
+        assertEquals("blocked", local.results[1].error)
+    }
+
+    @Test
+    fun `toLocalHistoryEntry derives name from path and maps repo keys`() {
+        val artifactId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val promotedBy = UUID.randomUUID()
+        val sdk = com.artifactkeeper.client.models.PromotionHistoryEntry(
+            artifactId = artifactId,
+            artifactPath = "com/example/app/1.2.3/app-1.2.3.jar",
+            createdAt = OffsetDateTime.parse("2026-01-15T10:30:00Z"),
+            id = id,
+            sourceRepoKey = "maven-staging",
+            status = "promoted",
+            targetRepoKey = "maven-releases",
+            notes = "release cut",
+            promotedBy = promotedBy,
+            promotedByUsername = "brandon",
+        )
+
+        val local = PromotionMapper.toLocalHistoryEntry(sdk)
+
+        assertEquals(id.toString(), local.id)
+        assertEquals(artifactId.toString(), local.artifactId)
+        assertEquals("app-1.2.3.jar", local.artifactName)
+        assertNull(local.artifactVersion)
+        assertEquals("maven-staging", local.sourceRepositoryKey)
+        assertEquals("maven-releases", local.targetRepositoryKey)
+        assertEquals(promotedBy.toString(), local.promotedBy)
+        assertEquals("brandon", local.promotedByUsername)
+        assertEquals("release cut", local.comment)
+        assertFalse(local.forced)
+        assertEquals("2026-01-15T10:30Z", local.promotedAt)
+    }
+}


### PR DESCRIPTION
## Summary
The app's promote/bulk/history calls used removed `/api/v1/staging/*` paths. v1.2.1 changed both the paths AND the request/response body shapes, so this is a real mapping migration, not a path swap:
- Routes to PromotionApi.promoteArtifact / promoteArtifactsBulk / promotionHistory (/api/v1/promotion/*) via the regenerated :sdk.
- New PromotionMapper translates local UI models <-> 1.2.1 promotion models (force -> skip_policy_check, comment -> notes, target key -> target_repository; bulk ids String -> UUID). Documents lossy fields where 1.2.1 dropped them (forced, history entry name/version).
- StagingViewModel uses the mapper; UI state contract unchanged.
- Dead staging-list call sites (listStagingRepos/listStagingArtifacts) marked with TODO referencing #81 (no 1.2.1 endpoint; needs a discovery redesign).

Tests: PromotionMapperTest (6) pinning the field mapping, StagingViewModelTest (14). Full unit suite green.

Closes #82
Part of #81

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] N/A - no UI changes (ViewModel mapping only; staging UI contract unchanged)