### PR TITLE
feat(artifacts): artifact detail screen with metadata, stats, labels

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -3,6 +3,8 @@ package com.artifactkeeper.android.data.api
 import com.artifactkeeper.android.BuildConfig
 import com.artifactkeeper.client.apis.AdminApi
 import com.artifactkeeper.client.apis.AnalyticsApi
+import com.artifactkeeper.client.apis.ArtifactLabelsApi
+import com.artifactkeeper.client.apis.ArtifactsApi
 import com.artifactkeeper.client.apis.AuthApi
 import com.artifactkeeper.client.apis.BuildsApi
 import com.artifactkeeper.client.apis.GroupsApi
@@ -47,6 +49,8 @@ object ApiClient {
 
     // --- Typed API services ---
     lateinit var authApi: AuthApi private set
+    lateinit var artifactsApi: ArtifactsApi private set
+    lateinit var artifactLabelsApi: ArtifactLabelsApi private set
     lateinit var reposApi: RepositoriesApi private set
     lateinit var packagesApi: PackagesApi private set
     lateinit var buildsApi: BuildsApi private set
@@ -109,6 +113,8 @@ object ApiClient {
         sdkClient = client
 
         authApi = client.createService(AuthApi::class.java)
+        artifactsApi = client.createService(ArtifactsApi::class.java)
+        artifactLabelsApi = client.createService(ArtifactLabelsApi::class.java)
         reposApi = client.createService(RepositoriesApi::class.java)
         packagesApi = client.createService(PackagesApi::class.java)
         buildsApi = client.createService(BuildsApi::class.java)

--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -41,6 +41,7 @@ import com.artifactkeeper.android.ui.components.AccountMenu
 import com.artifactkeeper.android.ui.screens.admin.GroupsScreen
 import com.artifactkeeper.android.ui.screens.admin.SSOScreen
 import com.artifactkeeper.android.ui.screens.admin.UsersScreen
+import com.artifactkeeper.android.ui.screens.artifacts.ArtifactDetailScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildDetailScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildsScreen
 import com.artifactkeeper.android.ui.screens.integration.PeersScreen
@@ -685,12 +686,20 @@ private fun NavGraphBuilder.detailRoutes(navController: NavHostController) {
         RepositoryDetailScreen(
             repoKey = key,
             onBack = { navController.popBackStack() },
+            onArtifactClick = { id -> navController.navigate("artifacts/$id") },
             onArtifactSecurityClick = { id, name ->
                 navController.navigate("artifacts/$id/security?name=$name")
             },
             onNavigateToMembers = { repoKey, repoName, repoFormat ->
                 navController.navigate("repos/$repoKey/members?name=$repoName&format=$repoFormat")
             },
+        )
+    }
+    composable("artifacts/{id}") { backStackEntry ->
+        val id = backStackEntry.arguments?.getString("id") ?: return@composable
+        ArtifactDetailScreen(
+            artifactId = id,
+            onBack = { navController.popBackStack() },
         )
     }
     composable("packages/{id}") { backStackEntry ->

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/artifacts/ArtifactDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/artifacts/ArtifactDetailScreen.kt
@@ -1,0 +1,256 @@
+package com.artifactkeeper.android.ui.screens.artifacts
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.artifactkeeper.android.ui.components.LoadingErrorContainer
+import com.artifactkeeper.android.ui.util.formatBytes
+import com.artifactkeeper.android.ui.util.formatRelativeTime
+import com.artifactkeeper.client.models.ArtifactLabelResponse
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArtifactDetailScreen(
+    artifactId: String,
+    onBack: () -> Unit,
+    viewModel: ArtifactDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(artifactId) { viewModel.load(artifactId) }
+
+    LaunchedEffect(state.labelError) {
+        state.labelError?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearLabelError()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(state.artifact?.name ?: "Artifact") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        LoadingErrorContainer(
+            isLoading = state.isLoading,
+            error = state.error,
+            onRetry = { viewModel.load(artifactId) },
+            modifier = Modifier.padding(innerPadding),
+        ) {
+            PullToRefreshBox(
+                isRefreshing = state.isRefreshing,
+                onRefresh = { viewModel.load(artifactId, refresh = true) },
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    state.artifact?.let { artifact ->
+                        item {
+                            SectionCard(title = "Details") {
+                                DetailRow("Repository", artifact.repositoryKey)
+                                DetailRow("Path", artifact.path)
+                                artifact.version?.let { DetailRow("Version", it) }
+                                DetailRow("Content type", artifact.contentType)
+                                DetailRow("Size", formatBytes(artifact.sizeBytes))
+                                DetailRow("Downloads", artifact.downloadCount.toString())
+                                DetailRow("Created", formatRelativeTime(artifact.createdAt))
+                                DetailRow("SHA-256", artifact.checksumSha256, monospace = true)
+                            }
+                        }
+                    }
+
+                    state.stats?.let { stats ->
+                        item {
+                            SectionCard(title = "Download stats") {
+                                DetailRow("Total downloads", stats.downloadCount.toString())
+                                stats.firstDownloaded?.let { DetailRow("First downloaded", formatRelativeTime(it)) }
+                                stats.lastDownloaded?.let { DetailRow("Last downloaded", formatRelativeTime(it)) }
+                            }
+                        }
+                    }
+
+                    state.metadata?.let { metadata ->
+                        item {
+                            SectionCard(title = "Metadata") {
+                                DetailRow("Format", metadata.format)
+                            }
+                        }
+                    }
+
+                    item {
+                        LabelsCard(
+                            labels = state.labels,
+                            isMutating = state.isLabelMutating,
+                            onAdd = { key, value -> viewModel.addLabel(key, value) },
+                            onDelete = { viewModel.deleteLabel(it) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionCard(title: String, content: @Composable () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String, monospace: Boolean = false) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = if (monospace) FontFamily.Monospace else FontFamily.Default,
+            modifier = Modifier.padding(start = 16.dp),
+        )
+    }
+}
+
+@Composable
+private fun LabelsCard(
+    labels: List<ArtifactLabelResponse>,
+    isMutating: Boolean,
+    onAdd: (key: String, value: String?) -> Unit,
+    onDelete: (key: String) -> Unit,
+) {
+    var newKey by remember { mutableStateOf("") }
+    var newValue by remember { mutableStateOf("") }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(
+                text = "Labels",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            if (labels.isEmpty()) {
+                Text(
+                    text = "No labels yet",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                labels.forEach { label ->
+                    AssistChip(
+                        onClick = { },
+                        label = { Text(labelText(label)) },
+                        trailingIcon = {
+                            IconButton(
+                                onClick = { onDelete(label.key) },
+                                enabled = !isMutating,
+                            ) {
+                                Icon(
+                                    Icons.Filled.Close,
+                                    contentDescription = "Remove ${label.key}",
+                                )
+                            }
+                        },
+                    )
+                }
+            }
+
+            OutlinedTextField(
+                value = newKey,
+                onValueChange = { newKey = it },
+                label = { Text("Key") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            OutlinedTextField(
+                value = newValue,
+                onValueChange = { newValue = it },
+                label = { Text("Value (optional)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(
+                    onClick = {
+                        onAdd(newKey.trim(), newValue.trim().ifBlank { null })
+                        newKey = ""
+                        newValue = ""
+                    },
+                    enabled = !isMutating && newKey.isNotBlank(),
+                ) {
+                    Icon(Icons.Filled.Add, contentDescription = null)
+                    Text(text = "Add label", modifier = Modifier.padding(start = 4.dp))
+                }
+            }
+        }
+    }
+}
+
+private fun labelText(label: ArtifactLabelResponse): String =
+    if (label.value.isBlank()) label.key else "${label.key}: ${label.value}"

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/artifacts/ArtifactDetailViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/artifacts/ArtifactDetailViewModel.kt
@@ -1,0 +1,146 @@
+package com.artifactkeeper.android.ui.screens.artifacts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.AddArtifactLabelRequest
+import com.artifactkeeper.client.models.ArtifactLabelResponse
+import com.artifactkeeper.client.models.ArtifactMetadataResponse
+import com.artifactkeeper.client.models.ArtifactResponse
+import com.artifactkeeper.client.models.ArtifactStatsResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+data class ArtifactDetailUiState(
+    val artifact: ArtifactResponse? = null,
+    val metadata: ArtifactMetadataResponse? = null,
+    val stats: ArtifactStatsResponse? = null,
+    val labels: List<ArtifactLabelResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isLabelMutating: Boolean = false,
+    val error: String? = null,
+    val labelError: String? = null,
+)
+
+@HiltViewModel
+class ArtifactDetailViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ArtifactDetailUiState())
+    val uiState: StateFlow<ArtifactDetailUiState> = _uiState.asStateFlow()
+
+    private var artifactId: UUID? = null
+
+    fun load(id: String, refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            val uuid = id.toUuidOrNull()
+            if (uuid == null) {
+                _uiState.update {
+                    it.copy(isLoading = false, isRefreshing = false, error = "Invalid artifact id")
+                }
+                return@launch
+            }
+            artifactId = uuid
+            try {
+                val artifact = apiClient.artifactsApi.getArtifact(uuid).unwrap()
+
+                // Metadata and stats are best-effort; an artifact can exist without either.
+                val metadata = runCatchingApi { apiClient.artifactsApi.getArtifactMetadata(uuid).unwrap() }
+                val stats = runCatchingApi { apiClient.artifactsApi.getArtifactStats(uuid).unwrap() }
+                val labels = runCatchingApi { apiClient.artifactLabelsApi.listArtifactLabels(uuid).unwrap()?.items }
+                    ?: emptyList()
+
+                _uiState.update {
+                    it.copy(
+                        artifact = artifact,
+                        metadata = metadata,
+                        stats = stats,
+                        labels = labels,
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = null,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = e.message ?: "Failed to load artifact",
+                    )
+                }
+            }
+        }
+    }
+
+    fun addLabel(key: String, value: String?) {
+        val uuid = artifactId ?: return
+        if (key.isBlank()) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLabelMutating = true, labelError = null) }
+            try {
+                apiClient.artifactLabelsApi
+                    .addArtifactLabel(uuid, key, AddArtifactLabelRequest(value = value))
+                    .unwrap()
+                refreshLabels(uuid)
+                _uiState.update { it.copy(isLabelMutating = false) }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(isLabelMutating = false, labelError = e.message ?: "Failed to add label")
+                }
+            }
+        }
+    }
+
+    fun deleteLabel(key: String) {
+        val uuid = artifactId ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLabelMutating = true, labelError = null) }
+            try {
+                apiClient.artifactLabelsApi.deleteArtifactLabel(uuid, key).unwrap()
+                refreshLabels(uuid)
+                _uiState.update { it.copy(isLabelMutating = false) }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(isLabelMutating = false, labelError = e.message ?: "Failed to delete label")
+                }
+            }
+        }
+    }
+
+    fun clearLabelError() {
+        _uiState.update { it.copy(labelError = null) }
+    }
+
+    private suspend fun refreshLabels(uuid: UUID) {
+        val labels = apiClient.artifactLabelsApi.listArtifactLabels(uuid).unwrap().items
+        _uiState.update { it.copy(labels = labels) }
+    }
+
+    private inline fun <T> runCatchingApi(block: () -> T?): T? =
+        try {
+            block()
+        } catch (_: Exception) {
+            null
+        }
+
+    private fun String.toUuidOrNull(): UUID? =
+        try {
+            UUID.fromString(this)
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Upload
@@ -46,6 +47,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 fun RepositoryDetailScreen(
     repoKey: String,
     onBack: () -> Unit,
+    onArtifactClick: (id: String) -> Unit = { },
     onArtifactSecurityClick: (id: String, name: String) -> Unit = { _, _ -> },
     onNavigateToMembers: ((repoKey: String, repoName: String, repoFormat: String) -> Unit)? = null,
 ) {
@@ -327,6 +329,7 @@ fun RepositoryDetailScreen(
                             ArtifactCard(
                                 artifact = artifact,
                                 repoKey = repoKey,
+                                onDetailsClick = { onArtifactClick(artifact.id.toString()) },
                                 onSecurityClick = { onArtifactSecurityClick(artifact.id.toString(), artifact.name) },
                             )
                         }
@@ -403,7 +406,12 @@ private fun RepoDetailHeader(repo: Repository) {
 }
 
 @Composable
-private fun ArtifactCard(artifact: Artifact, repoKey: String, onSecurityClick: () -> Unit) {
+private fun ArtifactCard(
+    artifact: Artifact,
+    repoKey: String,
+    onDetailsClick: () -> Unit,
+    onSecurityClick: () -> Unit,
+) {
     val context = LocalContext.current
 
     Card(
@@ -433,6 +441,17 @@ private fun ArtifactCard(artifact: Artifact, repoKey: String, onSecurityClick: (
                     AssistChip(
                         onClick = {},
                         label = { Text("v${artifact.version}", style = MaterialTheme.typography.labelSmall) },
+                    )
+                }
+                IconButton(
+                    onClick = onDetailsClick,
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    Icon(
+                        Icons.Default.Info,
+                        contentDescription = "Artifact details",
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.primary,
                     )
                 }
                 IconButton(

--- a/app/src/test/java/com/artifactkeeper/android/ArtifactDetailViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/ArtifactDetailViewModelTest.kt
@@ -1,0 +1,248 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.artifacts.ArtifactDetailUiState
+import com.artifactkeeper.android.ui.screens.artifacts.ArtifactDetailViewModel
+import com.artifactkeeper.client.apis.ArtifactLabelsApi
+import com.artifactkeeper.client.apis.ArtifactsApi
+import com.artifactkeeper.client.models.ArtifactLabelResponse
+import com.artifactkeeper.client.models.ArtifactLabelsListResponse
+import com.artifactkeeper.client.models.ArtifactMetadataResponse
+import com.artifactkeeper.client.models.ArtifactResponse
+import com.artifactkeeper.client.models.ArtifactStatsResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArtifactDetailViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockArtifactsApi = mockk<ArtifactsApi>()
+    private val mockLabelsApi = mockk<ArtifactLabelsApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { artifactsApi } returns mockArtifactsApi
+        every { artifactLabelsApi } returns mockLabelsApi
+    }
+
+    private val artifactId = UUID.randomUUID()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // =========================================================================
+    // Initial state
+    // =========================================================================
+
+    @Test
+    fun `initial state is empty and not loading`() {
+        val vm = ArtifactDetailViewModel(mockApiClient)
+        val state = vm.uiState.value
+        assertEquals(ArtifactDetailUiState(), state)
+        assertNull(state.artifact)
+        assertNull(state.metadata)
+        assertNull(state.stats)
+        assertTrue(state.labels.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    // =========================================================================
+    // load
+    // =========================================================================
+
+    @Test
+    fun `load populates artifact metadata stats and labels`() {
+        stubLoad()
+        val vm = ArtifactDetailViewModel(mockApiClient)
+
+        vm.load(artifactId.toString())
+
+        val state = vm.uiState.value
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertEquals("app.jar", state.artifact?.name)
+        assertEquals("maven", state.metadata?.format)
+        assertEquals(42L, state.stats?.downloadCount)
+        assertEquals(1, state.labels.size)
+        assertEquals("env", state.labels.first().key)
+        assertEquals("prod", state.labels.first().value)
+    }
+
+    @Test
+    fun `load sets error when the artifact call fails`() {
+        coEvery { mockArtifactsApi.getArtifact(any()) } returns Response.error(404, errorBody())
+        val vm = ArtifactDetailViewModel(mockApiClient)
+
+        vm.load(artifactId.toString())
+
+        val state = vm.uiState.value
+        assertFalse(state.isLoading)
+        assertEquals(true, state.error?.isNotBlank())
+        assertNull(state.artifact)
+    }
+
+    @Test
+    fun `load tolerates optional metadata and stats failures`() {
+        coEvery { mockArtifactsApi.getArtifact(artifactId) } returns Response.success(artifact())
+        coEvery { mockArtifactsApi.getArtifactMetadata(artifactId) } throws RuntimeException("no metadata")
+        coEvery { mockArtifactsApi.getArtifactStats(artifactId) } throws RuntimeException("no stats")
+        coEvery { mockLabelsApi.listArtifactLabels(artifactId) } returns
+            Response.success(ArtifactLabelsListResponse(items = emptyList(), total = 0))
+        val vm = ArtifactDetailViewModel(mockApiClient)
+
+        vm.load(artifactId.toString())
+
+        val state = vm.uiState.value
+        assertNull(state.error)
+        assertEquals("app.jar", state.artifact?.name)
+        assertNull(state.metadata)
+        assertNull(state.stats)
+    }
+
+    @Test
+    fun `load sets error for a malformed artifact id`() {
+        val vm = ArtifactDetailViewModel(mockApiClient)
+
+        vm.load("not-a-uuid")
+
+        assertEquals(true, vm.uiState.value.error?.isNotBlank())
+    }
+
+    // =========================================================================
+    // addLabel
+    // =========================================================================
+
+    @Test
+    fun `addLabel posts the label and refreshes the label list`() {
+        stubLoad()
+        coEvery { mockLabelsApi.addArtifactLabel(any(), any(), any()) } returns
+            Response.success(label("team", "platform"))
+        coEvery { mockLabelsApi.listArtifactLabels(artifactId) } returnsMany listOf(
+            Response.success(ArtifactLabelsListResponse(items = listOf(label("env", "prod")), total = 1)),
+            Response.success(
+                ArtifactLabelsListResponse(
+                    items = listOf(label("env", "prod"), label("team", "platform")),
+                    total = 2,
+                ),
+            ),
+        )
+        val vm = ArtifactDetailViewModel(mockApiClient)
+        vm.load(artifactId.toString())
+
+        vm.addLabel("team", "platform")
+
+        coVerify { mockLabelsApi.addArtifactLabel(artifactId, "team", any()) }
+        assertEquals(2, vm.uiState.value.labels.size)
+    }
+
+    // =========================================================================
+    // deleteLabel
+    // =========================================================================
+
+    @Test
+    fun `deleteLabel removes the label and refreshes the list`() {
+        stubLoad()
+        coEvery { mockLabelsApi.deleteArtifactLabel(artifactId, "env") } returns Response.success(Unit)
+        coEvery { mockLabelsApi.listArtifactLabels(artifactId) } returnsMany listOf(
+            Response.success(ArtifactLabelsListResponse(items = listOf(label("env", "prod")), total = 1)),
+            Response.success(ArtifactLabelsListResponse(items = emptyList(), total = 0)),
+        )
+        val vm = ArtifactDetailViewModel(mockApiClient)
+        vm.load(artifactId.toString())
+
+        vm.deleteLabel("env")
+
+        coVerify { mockLabelsApi.deleteArtifactLabel(artifactId, "env") }
+        assertTrue(vm.uiState.value.labels.isEmpty())
+    }
+
+    @Test
+    fun `addLabel surfaces an error without clobbering existing labels`() {
+        stubLoad()
+        coEvery { mockLabelsApi.addArtifactLabel(any(), any(), any()) } returns Response.error(500, errorBody())
+        val vm = ArtifactDetailViewModel(mockApiClient)
+        vm.load(artifactId.toString())
+
+        vm.addLabel("team", "platform")
+
+        val state = vm.uiState.value
+        assertEquals(true, state.labelError?.isNotBlank())
+        assertEquals(1, state.labels.size)
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private fun stubLoad() {
+        coEvery { mockArtifactsApi.getArtifact(artifactId) } returns Response.success(artifact())
+        coEvery { mockArtifactsApi.getArtifactMetadata(artifactId) } returns Response.success(metadata())
+        coEvery { mockArtifactsApi.getArtifactStats(artifactId) } returns Response.success(stats())
+        coEvery { mockLabelsApi.listArtifactLabels(artifactId) } returns
+            Response.success(ArtifactLabelsListResponse(items = listOf(label("env", "prod")), total = 1))
+    }
+
+    private fun artifact() = ArtifactResponse(
+        checksumSha256 = "abc123",
+        contentType = "application/java-archive",
+        createdAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+        downloadCount = 42,
+        id = artifactId,
+        name = "app.jar",
+        path = "com/example/app/1.0/app.jar",
+        repositoryKey = "maven-local",
+        sizeBytes = 2048,
+        version = "1.0",
+    )
+
+    private fun metadata() = ArtifactMetadataResponse(
+        artifactId = artifactId,
+        format = "maven",
+        metadata = null,
+        properties = null,
+    )
+
+    private fun stats() = ArtifactStatsResponse(
+        artifactId = artifactId,
+        downloadCount = 42,
+        firstDownloaded = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+        lastDownloaded = OffsetDateTime.parse("2026-02-01T00:00:00Z"),
+    )
+
+    private fun label(key: String, value: String) = ArtifactLabelResponse(
+        artifactId = artifactId,
+        createdAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+        id = UUID.randomUUID(),
+        key = key,
+        value = value,
+    )
+
+    private fun errorBody() =
+        "{\"error\":\"boom\"}".toResponseBody("application/json".toMediaType())
+}


### PR DESCRIPTION
## Summary
Adds the Artifact Detail experience for the 1.2.1 Artifacts section wave (wave A). Tapping the info action on a repository artifact row opens a new detail screen that shows core fields, download stats, format metadata, and an editable labels section.

Covered operations: `get_artifact`, `get_artifact_metadata`, `get_artifact_stats`, `list_artifact_labels`, `set_artifact_labels`, `add_artifact_label`, `delete_artifact_label`.

Implementation notes:
- `ArtifactDetailViewModel` (Hilt) loads artifact + metadata + stats + labels. Metadata and stats are best-effort, so an artifact without either still renders.
- `ArtifactDetailScreen` (Material 3) uses the shared `LoadingErrorContainer` for loading/error states, pull-to-refresh, and a labels editor with add/delete and snackbar error surfacing.
- `artifactsApi` and `artifactLabelsApi` wired into `ApiClient`.
- Navigation: `artifacts/{id}` route added; the repository artifact row gains an info action that opens it. Existing download (card tap) and security actions are preserved.

Closes #86
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New: `ArtifactDetailViewModelTest` (8 tests) covering load success, optional metadata/stats failures, malformed id, label add/delete with list refresh, and label error handling. Full unit suite green: 677 tests, 0 failures. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both pass.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes