### PR TITLE
feat(security): per-artifact scan results and SBOM screen

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -56,10 +56,10 @@ import com.artifactkeeper.android.ui.screens.repositories.RepositoriesScreen
 import com.artifactkeeper.android.ui.screens.repositories.RepositoryDetailScreen
 import com.artifactkeeper.android.ui.screens.repositories.VirtualMembersScreen
 import com.artifactkeeper.android.ui.screens.search.SearchScreen
+import com.artifactkeeper.android.ui.screens.security.ArtifactSecurityScreen
 import com.artifactkeeper.android.ui.screens.security.LicensePoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.PoliciesScreen
-import com.artifactkeeper.android.ui.screens.security.SbomScreen
-import com.artifactkeeper.android.ui.screens.security.ScanFindingsScreen
+import com.artifactkeeper.android.ui.screens.security.ScanDetailScreen
 import com.artifactkeeper.android.ui.screens.security.ScansScreen
 import com.artifactkeeper.android.ui.screens.security.SecurityScreen
 import com.artifactkeeper.android.ui.screens.settings.SettingsScreen
@@ -595,7 +595,7 @@ private fun SecuritySection(isCompact: Boolean, accountActions: @Composable () -
 
     Column(modifier = Modifier.fillMaxSize()) {
         if (selectedScanId != null) {
-            ScanFindingsScreen(
+            ScanDetailScreen(
                 scanId = selectedScanId!!,
                 onBack = { selectedScanId = null },
             )
@@ -709,10 +709,16 @@ private fun NavGraphBuilder.detailRoutes(navController: NavHostController) {
     }
     composable("artifacts/{id}/security?name={name}") { backStackEntry ->
         val id = backStackEntry.arguments?.getString("id") ?: return@composable
-        val name = backStackEntry.arguments?.getString("name") ?: "Artifact"
-        SbomScreen(
+        ArtifactSecurityScreen(
             artifactId = id,
-            artifactName = name,
+            onScanClick = { scanId -> navController.navigate("artifacts/$id/security/scans/$scanId") },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable("artifacts/{id}/security/scans/{scanId}") { backStackEntry ->
+        val scanId = backStackEntry.arguments?.getString("scanId") ?: return@composable
+        ScanDetailScreen(
+            scanId = scanId,
             onBack = { navController.popBackStack() },
         )
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityScreen.kt
@@ -1,0 +1,383 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.FindInPage
+import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material.icons.filled.Policy
+import androidx.compose.material.icons.filled.Scanner
+import androidx.compose.material.icons.filled.Security
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.android.ui.theme.Critical
+import com.artifactkeeper.android.ui.theme.High
+import com.artifactkeeper.android.ui.theme.Low
+import com.artifactkeeper.android.ui.theme.Medium
+import com.artifactkeeper.client.models.ComponentResponse
+import com.artifactkeeper.client.models.ScanResponse
+import com.artifactkeeper.client.models.SbomContentResponse
+import java.util.UUID
+
+private val StatusCompleted = Color(0xFF52C41A)
+private val StatusRunning = Color(0xFF1890FF)
+private val StatusFailed = Color(0xFFF5222D)
+private val StatusPending = Color(0xFFFAAD14)
+
+/**
+ * Per-artifact security overview: the scans that ran against the artifact and
+ * its generated SBOM. Tapping a scan opens [ScanDetailScreen].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArtifactSecurityScreen(
+    artifactId: String,
+    onScanClick: (String) -> Unit,
+    onBack: () -> Unit,
+    viewModel: ArtifactSecurityViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val parsedId = remember(artifactId) { runCatching { UUID.fromString(artifactId) }.getOrNull() }
+
+    LaunchedEffect(parsedId) {
+        parsedId?.let { viewModel.loadArtifactSecurity(it) }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("Artifact Security") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            },
+        )
+
+        when {
+            parsedId == null -> {
+                CenteredMessage("Invalid artifact id")
+            }
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.error != null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.loadArtifactSecurity(parsedId, refresh = true) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            else -> {
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    item {
+                        SectionHeader(icon = Icons.Default.Scanner, label = "Scans")
+                    }
+                    if (state.scans.isEmpty()) {
+                        item { EmptyHint("No scans have run against this artifact") }
+                    } else {
+                        items(state.scans, key = { it.id }) { scan ->
+                            ArtifactScanCard(scan, onClick = { onScanClick(scan.id.toString()) })
+                        }
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        SectionHeader(icon = Icons.Default.Inventory2, label = "SBOM")
+                    }
+                    val sbom = state.sbom
+                    if (sbom == null) {
+                        item { EmptyHint("No SBOM generated for this artifact") }
+                    } else {
+                        item { SbomSummaryCard(sbom) }
+                        if (state.components.isNotEmpty()) {
+                            item {
+                                Text(
+                                    text = "Components (${state.components.size})",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    modifier = Modifier.padding(top = 4.dp),
+                                )
+                            }
+                            items(state.components, key = { it.id }) { component ->
+                                ComponentRow(component)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(icon: ImageVector, label: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun ArtifactScanCard(scan: ScanResponse, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = artifactScanTypeIcon(scan.scanType),
+                        contentDescription = scan.scanType,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Text(
+                        text = scan.scanType.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                }
+                ArtifactStatusBadge(scan.status)
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Default.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "${scan.findingsCount} finding${if (scan.findingsCount != 1) "s" else ""}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            ArtifactSeverityRow(
+                critical = scan.criticalCount,
+                high = scan.highCount,
+                medium = scan.mediumCount,
+                low = scan.lowCount,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SbomSummaryCard(sbom: SbomContentResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Description,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                Text(
+                    text = "${sbom.format.uppercase()} ${sbom.formatVersion}",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                MetricColumn(label = "Components", value = sbom.componentCount.toString())
+                MetricColumn(label = "Dependencies", value = sbom.dependencyCount.toString())
+                MetricColumn(label = "Licenses", value = sbom.licenseCount.toString())
+            }
+            if (sbom.licenses.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = sbom.licenses.joinToString(", "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricColumn(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.Start) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun ComponentRow(component: ComponentResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = component.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                component.version?.takeIf { it.isNotBlank() }?.let { ver ->
+                    Text(
+                        text = ver,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            if (component.licenses.isNotEmpty()) {
+                Text(
+                    text = component.licenses.joinToString(", "),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ArtifactStatusBadge(status: String) {
+    val color = artifactStatusColor(status)
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = status.replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+internal fun ArtifactSeverityRow(critical: Int, high: Int, medium: Int, low: Int) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        SeverityPill(label = "C", count = critical, color = Critical)
+        SeverityPill(label = "H", count = high, color = High)
+        SeverityPill(label = "M", count = medium, color = Medium)
+        SeverityPill(label = "L", count = low, color = Low)
+    }
+}
+
+@Composable
+private fun SeverityPill(label: String, count: Int, color: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = "$label: $count",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+private fun CenteredMessage(text: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun EmptyHint(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(vertical = 8.dp),
+    )
+}
+
+internal fun artifactScanTypeIcon(scanType: String): ImageVector = when (scanType.lowercase()) {
+    "vulnerability" -> Icons.Default.BugReport
+    "license" -> Icons.Default.Policy
+    "malware" -> Icons.Default.Security
+    "sast", "static" -> Icons.Default.FindInPage
+    else -> Icons.Default.Scanner
+}
+
+internal fun artifactStatusColor(status: String): Color = when (status.lowercase()) {
+    "completed", "complete" -> StatusCompleted
+    "running", "in_progress" -> StatusRunning
+    "failed", "error" -> StatusFailed
+    "pending", "queued" -> StatusPending
+    else -> StatusPending
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityViewModel.kt
@@ -1,0 +1,132 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.ComponentResponse
+import com.artifactkeeper.client.models.FindingResponse
+import com.artifactkeeper.client.models.ScanResponse
+import com.artifactkeeper.client.models.SbomContentResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for the per-artifact security overview: the scans that ran against an
+ * artifact plus its generated SBOM and component list.
+ */
+data class ArtifactSecurityUiState(
+    val scans: List<ScanResponse> = emptyList(),
+    val sbom: SbomContentResponse? = null,
+    val components: List<ComponentResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * State for a single scan: the scan summary plus its individual findings.
+ */
+data class ScanDetailUiState(
+    val scan: ScanResponse? = null,
+    val findings: List<FindingResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class ArtifactSecurityViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ArtifactSecurityUiState())
+    val uiState: StateFlow<ArtifactSecurityUiState> = _uiState.asStateFlow()
+
+    private val _scanDetailState = MutableStateFlow(ScanDetailUiState())
+    val scanDetailState: StateFlow<ScanDetailUiState> = _scanDetailState.asStateFlow()
+
+    /**
+     * Load the scans and SBOM for an artifact. The SBOM is optional: an artifact
+     * may not have one generated yet, so a failure there does not fail the screen.
+     */
+    fun loadArtifactSecurity(artifactId: UUID, refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val scans = apiClient.securityApi.listArtifactScans(artifactId).unwrap().items
+
+                var sbom: SbomContentResponse? = null
+                var components: List<ComponentResponse> = emptyList()
+                try {
+                    sbom = apiClient.sbomApi.getSbomByArtifact(artifactId).unwrap()
+                    components = apiClient.sbomApi.getSbomComponents(sbom.id).unwrap()
+                } catch (_: Exception) {
+                    // No SBOM for this artifact yet; leave it absent.
+                }
+
+                _uiState.update {
+                    it.copy(
+                        scans = scans,
+                        sbom = sbom,
+                        components = components,
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load artifact security data",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Load a single scan summary and its findings, sorted most-severe first.
+     */
+    fun loadScanDetail(scanId: UUID) {
+        viewModelScope.launch {
+            _scanDetailState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val scan = apiClient.securityApi.getScan(scanId).unwrap()
+                val findings = apiClient.securityApi.listFindings(scanId).unwrap().items
+                    .sortedBy { severityRank(it.severity) }
+
+                _scanDetailState.update {
+                    it.copy(scan = scan, findings = findings, isLoading = false)
+                }
+            } catch (e: Exception) {
+                _scanDetailState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load scan detail",
+                        isLoading = false,
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        /** Lower rank sorts first, so critical findings appear at the top. */
+        fun severityRank(severity: String): Int = when (severity.lowercase()) {
+            "critical" -> 0
+            "high" -> 1
+            "medium" -> 2
+            "low" -> 3
+            else -> 4
+        }
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScanDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScanDetailScreen.kt
@@ -1,0 +1,325 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.android.ui.theme.Critical
+import com.artifactkeeper.android.ui.theme.High
+import com.artifactkeeper.android.ui.theme.Low
+import com.artifactkeeper.android.ui.theme.Medium
+import com.artifactkeeper.client.models.FindingResponse
+import com.artifactkeeper.client.models.ScanResponse
+import java.util.UUID
+
+private val FixedVersionGreen = Color(0xFF52C41A)
+
+/**
+ * Detail for a single scan: a summary header plus the list of vulnerabilities
+ * and CVEs found, ordered most-severe first.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScanDetailScreen(
+    scanId: String,
+    onBack: () -> Unit,
+    viewModel: ArtifactSecurityViewModel = hiltViewModel(),
+) {
+    val state by viewModel.scanDetailState.collectAsState()
+    val parsedId = remember(scanId) { runCatching { UUID.fromString(scanId) }.getOrNull() }
+
+    LaunchedEffect(parsedId) {
+        parsedId?.let { viewModel.loadScanDetail(it) }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("Scan Detail") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            },
+        )
+
+        when {
+            parsedId == null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = "Invalid scan id",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.error != null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.loadScanDetail(parsedId) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            else -> {
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    state.scan?.let { scan ->
+                        item { ScanSummaryCard(scan) }
+                    }
+
+                    item {
+                        Text(
+                            text = "Findings (${state.findings.size})",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+
+                    if (state.findings.isEmpty()) {
+                        item {
+                            Text(
+                                text = "No findings for this scan",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        items(state.findings, key = { it.id }) { finding ->
+                            FindingDetailCard(finding)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScanSummaryCard(scan: ScanResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = artifactScanTypeIcon(scan.scanType),
+                        contentDescription = scan.scanType,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Text(
+                        text = scan.scanType.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                }
+                ArtifactStatusBadge(scan.status)
+            }
+
+            scan.artifactName?.takeIf { it.isNotBlank() }?.let { name ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = buildString {
+                        append(name)
+                        scan.artifactVersion?.takeIf { it.isNotBlank() }?.let { append(" $it") }
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+            ArtifactSeverityRow(
+                critical = scan.criticalCount,
+                high = scan.highCount,
+                medium = scan.mediumCount,
+                low = scan.lowCount,
+            )
+
+            scan.errorMessage?.takeIf { it.isNotBlank() }?.let { err ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = err,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FindingDetailCard(finding: FindingResponse) {
+    val uriHandler = LocalUriHandler.current
+    val sevColor = severityColor(finding.severity)
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(sevColor.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = finding.severity.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = sevColor,
+                    )
+                }
+
+                if (finding.isAcknowledged) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(MaterialTheme.colorScheme.primaryContainer)
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.CheckCircle,
+                                contentDescription = "Acknowledged",
+                                modifier = Modifier.size(14.dp),
+                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                            Text(
+                                text = "Acknowledged",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = finding.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+
+            finding.cveId?.takeIf { it.isNotBlank() }?.let { cve ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = cve,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        textDecoration = TextDecoration.Underline,
+                    ),
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable {
+                        uriHandler.openUri("https://nvd.nist.gov/vuln/detail/$cve")
+                    },
+                )
+            }
+
+            val hasComponentInfo = !finding.affectedComponent.isNullOrBlank() ||
+                !finding.affectedVersion.isNullOrBlank() ||
+                !finding.fixedVersion.isNullOrBlank()
+            if (hasComponentInfo) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    finding.affectedComponent?.takeIf { it.isNotBlank() }?.let { comp ->
+                        Text(
+                            text = comp,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                        )
+                    }
+                    finding.affectedVersion?.takeIf { it.isNotBlank() }?.let { ver ->
+                        Text(
+                            text = ver,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                            color = Critical,
+                        )
+                    }
+                    finding.fixedVersion?.takeIf { it.isNotBlank() }?.let { fixed ->
+                        Icon(
+                            imageVector = Icons.Default.ArrowForward,
+                            contentDescription = "fixed in",
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = fixed,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontWeight = FontWeight.Medium,
+                            color = FixedVersionGreen,
+                        )
+                    }
+                }
+            }
+
+            finding.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+private fun severityColor(severity: String): Color = when (severity.lowercase()) {
+    "critical" -> Critical
+    "high" -> High
+    "medium" -> Medium
+    "low" -> Low
+    else -> Low
+}

--- a/app/src/test/java/com/artifactkeeper/android/ArtifactSecurityViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/ArtifactSecurityViewModelTest.kt
@@ -1,0 +1,264 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.security.ArtifactSecurityUiState
+import com.artifactkeeper.android.ui.screens.security.ArtifactSecurityViewModel
+import com.artifactkeeper.client.apis.SbomApi
+import com.artifactkeeper.client.apis.SecurityApi
+import com.artifactkeeper.client.models.ComponentResponse
+import com.artifactkeeper.client.models.FindingListResponse
+import com.artifactkeeper.client.models.FindingResponse
+import com.artifactkeeper.client.models.ScanListResponse
+import com.artifactkeeper.client.models.ScanResponse
+import com.artifactkeeper.client.models.SbomContentResponse
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ArtifactSecurityViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockSecurityApi = mockk<SecurityApi>()
+    private val mockSbomApi = mockk<SbomApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { securityApi } returns mockSecurityApi
+        every { sbomApi } returns mockSbomApi
+    }
+
+    private val artifactId = UUID.randomUUID()
+    private val repoId = UUID.randomUUID()
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun scan(
+        id: UUID = UUID.randomUUID(),
+        status: String = "completed",
+        critical: Int = 1,
+        high: Int = 2,
+    ) = ScanResponse(
+        artifactId = artifactId,
+        createdAt = now,
+        criticalCount = critical,
+        findingsCount = critical + high,
+        highCount = high,
+        id = id,
+        infoCount = 0,
+        isReused = false,
+        lowCount = 0,
+        mediumCount = 0,
+        repositoryId = repoId,
+        scanType = "vulnerability",
+        status = status,
+    )
+
+    private fun sbomContent() = SbomContentResponse(
+        artifactId = artifactId,
+        componentCount = 3,
+        contentHash = "abc123",
+        createdAt = now,
+        dependencyCount = 5,
+        format = "cyclonedx",
+        formatVersion = "1.5",
+        generatedAt = now,
+        id = UUID.randomUUID(),
+        licenseCount = 2,
+        licenses = listOf("MIT", "Apache-2.0"),
+        repositoryId = repoId,
+        content = emptyMap<String, Any>(),
+    )
+
+    private fun component(name: String) = ComponentResponse(
+        id = UUID.randomUUID(),
+        licenses = listOf("MIT"),
+        name = name,
+        sbomId = UUID.randomUUID(),
+    )
+
+    private fun finding(severity: String) = FindingResponse(
+        artifactId = artifactId,
+        createdAt = now,
+        id = UUID.randomUUID(),
+        isAcknowledged = false,
+        scanResultId = UUID.randomUUID(),
+        severity = severity,
+        title = "Vuln in $severity",
+    )
+
+    // =========================================================================
+    // ArtifactSecurityUiState data class
+    // =========================================================================
+
+    @Test
+    fun `initial state is empty with no loading flags`() {
+        val state = ArtifactSecurityUiState()
+        assertTrue(state.scans.isEmpty())
+        assertNull(state.sbom)
+        assertTrue(state.components.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `ui state copy preserves unmodified fields`() {
+        val original = ArtifactSecurityUiState(isLoading = true, error = "boom")
+        val copied = original.copy(isLoading = false)
+        assertFalse(copied.isLoading)
+        assertEquals("boom", copied.error)
+    }
+
+    // =========================================================================
+    // loadArtifactSecurity: scans + sbom
+    // =========================================================================
+
+    @Test
+    fun `loadArtifactSecurity populates scans and sbom on success`() = runTest {
+        val scans = listOf(scan(critical = 3, high = 1), scan(critical = 0, high = 0))
+        coEvery { mockSecurityApi.listArtifactScans(artifactId) } returns
+            Response.success(ScanListResponse(items = scans, total = 2))
+        coEvery { mockSbomApi.getSbomByArtifact(artifactId) } returns
+            Response.success(sbomContent())
+        coEvery { mockSbomApi.getSbomComponents(any()) } returns
+            Response.success(listOf(component("libfoo"), component("libbar")))
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.loadArtifactSecurity(artifactId)
+
+        val state = vm.uiState.value
+        assertEquals(2, state.scans.size)
+        assertNotNull(state.sbom)
+        assertEquals(2, state.components.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadArtifactSecurity tolerates missing sbom and still shows scans`() = runTest {
+        coEvery { mockSecurityApi.listArtifactScans(artifactId) } returns
+            Response.success(ScanListResponse(items = listOf(scan()), total = 1))
+        // No SBOM generated for this artifact yet -> 404
+        coEvery { mockSbomApi.getSbomByArtifact(artifactId) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "not found"))
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.loadArtifactSecurity(artifactId)
+
+        val state = vm.uiState.value
+        assertEquals(1, state.scans.size)
+        assertNull(state.sbom)
+        assertTrue(state.components.isEmpty())
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadArtifactSecurity sets error when scan listing fails`() = runTest {
+        coEvery { mockSecurityApi.listArtifactScans(artifactId) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "server error"))
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.loadArtifactSecurity(artifactId)
+
+        val state = vm.uiState.value
+        assertNotNull(state.error)
+        assertFalse(state.isLoading)
+    }
+
+    // =========================================================================
+    // loadScanDetail: get_scan + list_findings
+    // =========================================================================
+
+    @Test
+    fun `loadScanDetail populates scan and findings`() = runTest {
+        val scanId = UUID.randomUUID()
+        coEvery { mockSecurityApi.getScan(scanId) } returns Response.success(scan(id = scanId))
+        coEvery { mockSecurityApi.listFindings(scanId) } returns Response.success(
+            FindingListResponse(
+                items = listOf(finding("critical"), finding("high"), finding("low")),
+                total = 3,
+            ),
+        )
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.loadScanDetail(scanId)
+
+        val state = vm.scanDetailState.value
+        assertEquals(scanId, state.scan?.id)
+        assertEquals(3, state.findings.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadScanDetail sets error when get scan fails`() = runTest {
+        val scanId = UUID.randomUUID()
+        coEvery { mockSecurityApi.getScan(scanId) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.loadScanDetail(scanId)
+
+        val state = vm.scanDetailState.value
+        assertNotNull(state.error)
+        assertNull(state.scan)
+    }
+
+    // =========================================================================
+    // findings are sorted by severity for display
+    // =========================================================================
+
+    @Test
+    fun `severity rank orders critical before low`() {
+        assertTrue(
+            ArtifactSecurityViewModel.severityRank("critical") <
+                ArtifactSecurityViewModel.severityRank("low"),
+        )
+        assertTrue(
+            ArtifactSecurityViewModel.severityRank("high") <
+                ArtifactSecurityViewModel.severityRank("medium"),
+        )
+    }
+
+    @Test
+    fun `loadScanDetail sorts findings by descending severity`() = runTest {
+        val scanId = UUID.randomUUID()
+        coEvery { mockSecurityApi.getScan(scanId) } returns Response.success(scan(id = scanId))
+        coEvery { mockSecurityApi.listFindings(scanId) } returns Response.success(
+            FindingListResponse(
+                items = listOf(finding("low"), finding("critical"), finding("medium")),
+                total = 3,
+            ),
+        )
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.loadScanDetail(scanId)
+
+        val severities = vm.scanDetailState.value.findings.map { it.severity }
+        assertEquals(listOf("critical", "medium", "low"), severities)
+    }
+}

--- a/docs/parity-matrix-1.2.1.md
+++ b/docs/parity-matrix-1.2.1.md
@@ -18,11 +18,11 @@ SDK module: vendored `:sdk` regenerated from v1.2.1 (openapi-generator 7.21.0, k
 | Artifacts | 14 | 0 | 48 | 0 | 62 |
 | Staging | 0 | 3 | 30 | 0 | 33 |
 | Integration | 12 | 0 | 60 | 0 | 72 |
-| Security | 15 | 0 | 57 | 0 | 72 |
+| Security | 18 | 0 | 54 | 0 | 72 |
 | Operations | 2 | 0 | 21 | 0 | 23 |
 | Administration | 8 | 0 | 92 | 16 | 116 |
 | Cross-cutting | 8 | 0 | 4 | 0 | 12 |
-| **All** | **59** | **3** | **312** | **16** | **390** |
+| **All** | **62** | **3** | **309** | **16** | **390** |
 
 ## Artifacts
 
@@ -227,7 +227,7 @@ SDK module: vendored `:sdk` regenerated from v1.2.1 (openapi-generator 7.21.0, k
 | quality | `POST /api/v1/quality/issues/{id}/suppress` | `suppress_issue` | missing | Security |  |  |
 | sbom | `GET /api/v1/sbom` | `list_sboms` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/SbomScreen.kt` |  |
 | sbom | `POST /api/v1/sbom` | `generate_sbom` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/SbomScreen.kt` |  |
-| sbom | `GET /api/v1/sbom/by-artifact/{artifact_id}` | `get_sbom_by_artifact` | missing | Security |  |  |
+| sbom | `GET /api/v1/sbom/by-artifact/{artifact_id}` | `get_sbom_by_artifact` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityScreen.kt` |  |
 | sbom | `POST /api/v1/sbom/check-compliance` | `check_license_compliance` | missing | Security |  |  |
 | sbom | `GET /api/v1/sbom/cve/history/by-artifact/{artifact_id}` | `get_cve_history_by_artifact` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/SbomScreen.kt` |  |
 | sbom | `GET /api/v1/sbom/cve/history/by-cve/{cve_id}` | `get_cve_history_by_cve` | missing | Security |  |  |
@@ -257,7 +257,7 @@ SDK module: vendored `:sdk` regenerated from v1.2.1 (openapi-generator 7.21.0, k
 | security | `GET /api/v1/repositories/{key}/security` | `get_repo_security` | missing | Security |  |  |
 | security | `PUT /api/v1/repositories/{key}/security` | `update_repo_security` | missing | Security |  |  |
 | security | `GET /api/v1/repositories/{key}/security/scans` | `list_repo_scans` | missing | Security |  |  |
-| security | `GET /api/v1/security/artifacts/{artifact_id}/scans` | `list_artifact_scans` | missing | Security |  |  |
+| security | `GET /api/v1/security/artifacts/{artifact_id}/scans` | `list_artifact_scans` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityScreen.kt` |  |
 | security | `GET /api/v1/security/configs` | `list_scan_configs` | missing | Security |  |  |
 | security | `GET /api/v1/security/dashboard` | `get_dashboard` | missing | Security |  |  |
 | security | `DELETE /api/v1/security/findings/{id}/acknowledge` | `revoke_acknowledgment` | missing | Security |  |  |
@@ -269,8 +269,8 @@ SDK module: vendored `:sdk` regenerated from v1.2.1 (openapi-generator 7.21.0, k
 | security | `PUT /api/v1/security/policies/{id}` | `update_policy` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/PoliciesScreen.kt` |  |
 | security | `POST /api/v1/security/scan` | `trigger_scan` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScansScreen.kt` |  |
 | security | `GET /api/v1/security/scans` | `list_scans` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScansScreen.kt` |  |
-| security | `GET /api/v1/security/scans/{id}` | `get_scan` | missing | Security |  |  |
-| security | `GET /api/v1/security/scans/{id}/findings` | `list_findings` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScanFindingsScreen.kt` |  |
+| security | `GET /api/v1/security/scans/{id}` | `get_scan` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScanDetailScreen.kt` |  |
+| security | `GET /api/v1/security/scans/{id}/findings` | `list_findings` | exists | Security | `app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScanDetailScreen.kt` |  |
 | security | `GET /api/v1/security/scores` | `get_all_scores` | missing | Security |  |  |
 | signing | `GET /api/v1/signing/keys` | `list_keys` | missing | Security |  |  |
 | signing | `POST /api/v1/signing/keys` | `create_key` | missing | Security |  |  |


### PR DESCRIPTION
## Summary
Adds the highest-value Security cluster for 1.2.1 parity: a per-artifact security view and a scan detail screen.

- `ArtifactSecurityScreen` lists the scans run against an artifact (severity color coding, status badges) and shows the artifact's SBOM summary (format, component/dependency/license counts) plus its component list. Tapping a scan opens the detail screen.
- `ScanDetailScreen` shows a scan summary header (type, status, severity counts) and the findings list, ordered most-severe first, with clickable CVE links to NVD and affected/fixed version info.
- `ArtifactSecurityViewModel` is Hilt-injected and backs both screens, with empty/loading/error states. The SBOM is treated as optional so an artifact without one still shows its scans.
- Navigation: the Scans drill-down now opens `ScanDetailScreen` (was the findings-only screen), and the repository artifact-security entry point now opens the combined `ArtifactSecurityScreen`.

Wires the previously missing 1.2.1 Security operations: `list_artifact_scans`, `get_scan`, `get_sbom_by_artifact`. `get_sbom`, `get_sbom_components`, and `list_findings` were already present and are surfaced through the new screens. Parity matrix updated: Security exists 15 to 18, missing 57 to 54.

Closes #87
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`ArtifactSecurityViewModelTest`: 9 tests, all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes