### PR TITLE
feat(security): Dependency-Track projects and project detail

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -58,6 +58,8 @@ import com.artifactkeeper.android.ui.screens.repositories.RepositoryDetailScreen
 import com.artifactkeeper.android.ui.screens.repositories.VirtualMembersScreen
 import com.artifactkeeper.android.ui.screens.search.SearchScreen
 import com.artifactkeeper.android.ui.screens.security.ArtifactSecurityScreen
+import com.artifactkeeper.android.ui.screens.security.DependencyTrackScreen
+import com.artifactkeeper.android.ui.screens.security.DtProjectDetailScreen
 import com.artifactkeeper.android.ui.screens.security.LicensePoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.PoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.ScanDetailScreen
@@ -590,15 +592,22 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SecuritySection(isCompact: Boolean, accountActions: @Composable () -> Unit) {
-    val subTabs = listOf("Dashboard", "Scans", "Policies", "Licenses")
+    val subTabs = listOf("Dashboard", "Scans", "Dep-Track", "Policies", "Licenses")
     var selectedTab by remember { mutableIntStateOf(0) }
     var selectedScanId by remember { mutableStateOf<String?>(null) }
+    var selectedDtProject by remember { mutableStateOf<Pair<String, String>?>(null) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         if (selectedScanId != null) {
             ScanDetailScreen(
                 scanId = selectedScanId!!,
                 onBack = { selectedScanId = null },
+            )
+        } else if (selectedDtProject != null) {
+            DtProjectDetailScreen(
+                projectUuid = selectedDtProject!!.first,
+                projectName = selectedDtProject!!.second,
+                onBack = { selectedDtProject = null },
             )
         } else {
             TopAppBar(
@@ -621,8 +630,11 @@ private fun SecuritySection(isCompact: Boolean, accountActions: @Composable () -
             when (selectedTab) {
                 0 -> SecurityScreen()
                 1 -> ScansScreen(onScanClick = { selectedScanId = it })
-                2 -> PoliciesScreen()
-                3 -> LicensePoliciesScreen()
+                2 -> DependencyTrackScreen(
+                    onProjectClick = { uuid, name -> selectedDtProject = uuid to name },
+                )
+                3 -> PoliciesScreen()
+                4 -> LicensePoliciesScreen()
             }
         }
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/DependencyTrackScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/DependencyTrackScreen.kt
@@ -1,0 +1,423 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Inventory2
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.android.ui.theme.Critical
+import com.artifactkeeper.android.ui.theme.High
+import com.artifactkeeper.android.ui.theme.Low
+import com.artifactkeeper.android.ui.theme.Medium
+import com.artifactkeeper.client.models.DtFinding
+import com.artifactkeeper.client.models.DtPolicyViolation
+import com.artifactkeeper.client.models.DtProject
+import com.artifactkeeper.client.models.DtProjectMetrics
+
+private val ViolationColor = Color(0xFFFA8C16)
+
+/**
+ * Lists the Dependency-Track projects tracked by the server. Tapping a project
+ * opens [DtProjectDetailScreen].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DependencyTrackScreen(
+    onProjectClick: (uuid: String, name: String) -> Unit,
+    viewModel: DependencyTrackViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadProjects() }
+
+    when {
+        state.isLoading -> {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+        state.error != null -> {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = state.error ?: "Unknown error",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    TextButton(onClick = { viewModel.loadProjects(refresh = true) }) {
+                        Text("Retry")
+                    }
+                }
+            }
+        }
+        state.projects.isEmpty() -> {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    text = "No Dependency-Track projects",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        else -> {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                items(state.projects, key = { it.uuid }) { project ->
+                    DtProjectCard(
+                        project = project,
+                        onClick = { onProjectClick(project.uuid, project.name) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DtProjectCard(project: DtProject, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.weight(1f),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Inventory2,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = project.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    project.version?.takeIf { it.isNotBlank() }?.let { ver ->
+                        Text(
+                            text = ver,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * Detail for a single Dependency-Track project: severity metrics, the list of
+ * findings (most severe first), and any policy violations.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DtProjectDetailScreen(
+    projectUuid: String,
+    projectName: String,
+    onBack: () -> Unit,
+    viewModel: DependencyTrackViewModel = hiltViewModel(),
+) {
+    val state by viewModel.projectDetailState.collectAsState()
+
+    LaunchedEffect(projectUuid) { viewModel.loadProjectDetail(projectUuid) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {
+                Text(projectName, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            },
+        )
+
+        when {
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.error != null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.loadProjectDetail(projectUuid) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            else -> {
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    state.metrics?.let { metrics ->
+                        item { DtMetricsCard(metrics) }
+                    }
+
+                    if (state.violations.isNotEmpty()) {
+                        item {
+                            Text(
+                                text = "Policy Violations (${state.violations.size})",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                        items(state.violations, key = { it.uuid }) { violation ->
+                            DtViolationCard(violation)
+                        }
+                    }
+
+                    item {
+                        Text(
+                            text = "Findings (${state.findings.size})",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
+                    if (state.findings.isEmpty()) {
+                        item {
+                            Text(
+                                text = "No findings for this project",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        items(state.findings, key = { it.vulnerability.uuid }) { finding ->
+                            DtFindingCard(finding)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DtMetricsCard(metrics: DtProjectMetrics) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Vulnerabilities",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                DtSeverityPill("C", metrics.critical ?: 0, Critical)
+                DtSeverityPill("H", metrics.high ?: 0, High)
+                DtSeverityPill("M", metrics.medium ?: 0, Medium)
+                DtSeverityPill("L", metrics.low ?: 0, Low)
+            }
+
+            val total = metrics.findingsTotal ?: 0L
+            val audited = metrics.findingsAudited ?: 0L
+            if (total > 0) {
+                Spacer(modifier = Modifier.height(12.dp))
+                LinearProgressIndicator(
+                    progress = { audited.toFloat() / total.toFloat() },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(8.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = "Audited $audited / $total findings",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DtViolationCard(violation: DtPolicyViolation) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(ViolationColor.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = violation.type.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = ViolationColor,
+                    )
+                }
+                Text(
+                    text = violation.policyCondition.policy.name,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = buildString {
+                    violation.component.group?.takeIf { it.isNotBlank() }?.let { append("$it:") }
+                    append(violation.component.name)
+                    violation.component.version?.takeIf { it.isNotBlank() }?.let { append(" $it") }
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DtFindingCard(finding: DtFinding) {
+    val vuln = finding.vulnerability
+    val sevColor = dtSeverityColor(vuln.severity)
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(sevColor.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = vuln.severity.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = sevColor,
+                    )
+                }
+                if (finding.analysis?.isSuppressed == true) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        Text(
+                            text = "Suppressed",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "${vuln.source} ${vuln.vulnId}",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+
+            vuln.title?.takeIf { it.isNotBlank() }?.let { title ->
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = buildString {
+                    finding.component.group?.takeIf { it.isNotBlank() }?.let { append("$it:") }
+                    append(finding.component.name)
+                    finding.component.version?.takeIf { it.isNotBlank() }?.let { append(" $it") }
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            vuln.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DtSeverityPill(label: String, count: Long, color: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = "$label: $count",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+private fun dtSeverityColor(severity: String): Color = when (severity.uppercase()) {
+    "CRITICAL" -> Critical
+    "HIGH" -> High
+    "MEDIUM" -> Medium
+    "LOW" -> Low
+    else -> Low
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/DependencyTrackViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/DependencyTrackViewModel.kt
@@ -1,0 +1,128 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.DtFinding
+import com.artifactkeeper.client.models.DtPolicyViolation
+import com.artifactkeeper.client.models.DtProject
+import com.artifactkeeper.client.models.DtProjectMetrics
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * State for the Dependency-Track project list.
+ */
+data class DependencyTrackUiState(
+    val projects: List<DtProject> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * State for a single Dependency-Track project: its metrics, findings, and any
+ * policy violations.
+ */
+data class DtProjectDetailUiState(
+    val metrics: DtProjectMetrics? = null,
+    val findings: List<DtFinding> = emptyList(),
+    val violations: List<DtPolicyViolation> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class DependencyTrackViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DependencyTrackUiState())
+    val uiState: StateFlow<DependencyTrackUiState> = _uiState.asStateFlow()
+
+    private val _projectDetailState = MutableStateFlow(DtProjectDetailUiState())
+    val projectDetailState: StateFlow<DtProjectDetailUiState> = _projectDetailState.asStateFlow()
+
+    fun loadProjects(refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val projects = apiClient.securityApi.listProjects().unwrap()
+                _uiState.update {
+                    it.copy(
+                        projects = projects.sortedBy { p -> p.name.lowercase() },
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load Dependency-Track projects",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Load metrics, findings, and policy violations for a project. Violations are
+     * optional: a project may have no policies bound, so a failure there does not
+     * fail the screen.
+     */
+    fun loadProjectDetail(projectUuid: String) {
+        viewModelScope.launch {
+            _projectDetailState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val metrics = apiClient.securityApi.getProjectMetrics(projectUuid).unwrap()
+                val findings = apiClient.securityApi.getProjectFindings(projectUuid).unwrap()
+                    .sortedBy { dtSeverityRank(it.vulnerability.severity) }
+
+                var violations: List<DtPolicyViolation> = emptyList()
+                try {
+                    violations = apiClient.securityApi.getProjectViolations(projectUuid).unwrap()
+                } catch (_: Exception) {
+                    // No policy violations available for this project.
+                }
+
+                _projectDetailState.update {
+                    it.copy(
+                        metrics = metrics,
+                        findings = findings,
+                        violations = violations,
+                        isLoading = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _projectDetailState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load project detail",
+                        isLoading = false,
+                    )
+                }
+            }
+        }
+    }
+
+    companion object {
+        /** Lower rank sorts first, so critical findings appear at the top. */
+        fun dtSeverityRank(severity: String): Int = when (severity.uppercase()) {
+            "CRITICAL" -> 0
+            "HIGH" -> 1
+            "MEDIUM" -> 2
+            "LOW" -> 3
+            else -> 4
+        }
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/DependencyTrackViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/DependencyTrackViewModelTest.kt
@@ -1,0 +1,229 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.security.DependencyTrackUiState
+import com.artifactkeeper.android.ui.screens.security.DependencyTrackViewModel
+import com.artifactkeeper.android.ui.screens.security.DtProjectDetailUiState
+import com.artifactkeeper.client.apis.SecurityApi
+import com.artifactkeeper.client.models.DtComponent
+import com.artifactkeeper.client.models.DtFinding
+import com.artifactkeeper.client.models.DtPolicy
+import com.artifactkeeper.client.models.DtPolicyCondition
+import com.artifactkeeper.client.models.DtPolicyViolation
+import com.artifactkeeper.client.models.DtProject
+import com.artifactkeeper.client.models.DtProjectMetrics
+import com.artifactkeeper.client.models.DtVulnerability
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DependencyTrackViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockSecurityApi = mockk<SecurityApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { securityApi } returns mockSecurityApi
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun project(uuid: String, name: String) = DtProject(name = name, uuid = uuid)
+
+    private fun metrics(critical: Long = 2, high: Long = 3) = DtProjectMetrics(
+        critical = critical,
+        high = high,
+        medium = 1,
+        low = 0,
+        findingsTotal = critical + high + 1,
+        findingsAudited = 1,
+        vulnerabilities = critical + high + 1,
+        policyViolationsTotal = 0,
+    )
+
+    private fun finding(severity: String, vulnId: String) = DtFinding(
+        component = DtComponent(name = "libfoo", uuid = "c-1", version = "1.0.0"),
+        vulnerability = DtVulnerability(
+            severity = severity,
+            source = "NVD",
+            uuid = "v-$vulnId",
+            vulnId = vulnId,
+            title = "Issue $vulnId",
+        ),
+    )
+
+    private fun violation(uuid: String, type: String) = DtPolicyViolation(
+        component = DtComponent(name = "libbar", uuid = "c-2"),
+        policyCondition = DtPolicyCondition(
+            operator = "IS",
+            policy = DtPolicy(name = "License", uuid = "pol-1", violationState = "FAIL"),
+            subject = "LICENSE",
+            uuid = "pc-$uuid",
+            value = "GPL-3.0",
+        ),
+        type = type,
+        uuid = uuid,
+    )
+
+    // =========================================================================
+    // UI state
+    // =========================================================================
+
+    @Test
+    fun `initial list state is empty`() {
+        val state = DependencyTrackUiState()
+        assertTrue(state.projects.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `initial detail state is empty`() {
+        val state = DtProjectDetailUiState()
+        assertNull(state.metrics)
+        assertTrue(state.findings.isEmpty())
+        assertTrue(state.violations.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    // =========================================================================
+    // loadProjects
+    // =========================================================================
+
+    @Test
+    fun `loadProjects populates the project list`() = runTest {
+        coEvery { mockSecurityApi.listProjects() } returns Response.success(
+            listOf(project("p-1", "alpha"), project("p-2", "beta")),
+        )
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadProjects()
+
+        val state = vm.uiState.value
+        assertEquals(2, state.projects.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadProjects sets error on failure`() = runTest {
+        coEvery { mockSecurityApi.listProjects() } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadProjects()
+
+        val state = vm.uiState.value
+        assertTrue(state.projects.isEmpty())
+        assertNotNull(state.error)
+        assertFalse(state.isLoading)
+    }
+
+    // =========================================================================
+    // loadProjectDetail
+    // =========================================================================
+
+    @Test
+    fun `loadProjectDetail aggregates metrics findings and violations`() = runTest {
+        coEvery { mockSecurityApi.getProjectMetrics("p-1") } returns Response.success(metrics())
+        coEvery { mockSecurityApi.getProjectFindings("p-1") } returns Response.success(
+            listOf(finding("LOW", "CVE-1"), finding("CRITICAL", "CVE-2")),
+        )
+        coEvery { mockSecurityApi.getProjectViolations("p-1") } returns Response.success(
+            listOf(violation("vio-1", "SECURITY")),
+        )
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadProjectDetail("p-1")
+
+        val state = vm.projectDetailState.value
+        assertNotNull(state.metrics)
+        assertEquals(2, state.findings.size)
+        assertEquals(1, state.violations.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadProjectDetail orders findings most severe first`() = runTest {
+        coEvery { mockSecurityApi.getProjectMetrics("p-1") } returns Response.success(metrics())
+        coEvery { mockSecurityApi.getProjectFindings("p-1") } returns Response.success(
+            listOf(finding("LOW", "CVE-1"), finding("CRITICAL", "CVE-2"), finding("MEDIUM", "CVE-3")),
+        )
+        coEvery { mockSecurityApi.getProjectViolations("p-1") } returns Response.success(emptyList())
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadProjectDetail("p-1")
+
+        val severities = vm.projectDetailState.value.findings.map { it.vulnerability.severity }
+        assertEquals(listOf("CRITICAL", "MEDIUM", "LOW"), severities)
+    }
+
+    @Test
+    fun `loadProjectDetail tolerates missing violations`() = runTest {
+        coEvery { mockSecurityApi.getProjectMetrics("p-1") } returns Response.success(metrics())
+        coEvery { mockSecurityApi.getProjectFindings("p-1") } returns Response.success(
+            listOf(finding("HIGH", "CVE-9")),
+        )
+        // Policy violations endpoint not available -> 404
+        coEvery { mockSecurityApi.getProjectViolations("p-1") } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "no policies"))
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadProjectDetail("p-1")
+
+        val state = vm.projectDetailState.value
+        assertEquals(1, state.findings.size)
+        assertTrue(state.violations.isEmpty())
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadProjectDetail sets error when metrics fail`() = runTest {
+        coEvery { mockSecurityApi.getProjectMetrics("p-1") } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadProjectDetail("p-1")
+
+        val state = vm.projectDetailState.value
+        assertNotNull(state.error)
+        assertNull(state.metrics)
+    }
+
+    @Test
+    fun `dtSeverityRank orders critical before low`() {
+        assertTrue(
+            DependencyTrackViewModel.dtSeverityRank("CRITICAL") <
+                DependencyTrackViewModel.dtSeverityRank("LOW"),
+        )
+        assertTrue(
+            DependencyTrackViewModel.dtSeverityRank("HIGH") <
+                DependencyTrackViewModel.dtSeverityRank("MEDIUM"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds the Dependency-Track project drill-down to the Security section, building on the portfolio summary already shown on the dashboard.

- New "Dep-Track" sub-tab in the Security section. `DependencyTrackScreen` lists tracked DT projects (name + version), sorted alphabetically.
- `DtProjectDetailScreen` shows a metrics card (critical/high/medium/low severity pills + audit-progress bar), any policy violations, and the findings list ordered most-severe first with source/vuln id, title, affected component, and description. Suppressed findings are marked.
- `DependencyTrackViewModel` is Hilt-injected and backs both screens, with empty/loading/error states. Policy violations are treated as optional so a project with no bound policies still renders.

Rebased onto main (after #89 and #88 landed); kept all nav-host routes/tabs (ScanDetail + ArtifactSecurity from #89, plus the new Dep-Track tab and DtProjectDetail). No parity-matrix edits (matrix maintained centrally).

Operations wired (previously missing):
- `list_projects` (GET /api/v1/dependency-track/projects)
- `get_project_metrics` (GET /api/v1/dependency-track/projects/{project_uuid}/metrics)
- `get_project_findings` (GET /api/v1/dependency-track/projects/{project_uuid}/findings)
- `get_project_violations` (GET /api/v1/dependency-track/projects/{project_uuid}/violations)

Part of #80
Closes #90

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`DependencyTrackViewModelTest`: 9 tests, all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both green post-rebase.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes