### PR TITLE
feat(artifacts): repository file-tree browser

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -42,6 +42,7 @@ import com.artifactkeeper.android.ui.screens.admin.GroupsScreen
 import com.artifactkeeper.android.ui.screens.admin.SSOScreen
 import com.artifactkeeper.android.ui.screens.admin.UsersScreen
 import com.artifactkeeper.android.ui.screens.artifacts.ArtifactDetailScreen
+import com.artifactkeeper.android.ui.screens.artifacts.RepositoryBrowseScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildDetailScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildsScreen
 import com.artifactkeeper.android.ui.screens.integration.PeersScreen
@@ -687,12 +688,20 @@ private fun NavGraphBuilder.detailRoutes(navController: NavHostController) {
             repoKey = key,
             onBack = { navController.popBackStack() },
             onArtifactClick = { id -> navController.navigate("artifacts/$id") },
+            onBrowseFiles = { repoKey -> navController.navigate("repos/$repoKey/browse") },
             onArtifactSecurityClick = { id, name ->
                 navController.navigate("artifacts/$id/security?name=$name")
             },
             onNavigateToMembers = { repoKey, repoName, repoFormat ->
                 navController.navigate("repos/$repoKey/members?name=$repoName&format=$repoFormat")
             },
+        )
+    }
+    composable("repos/{key}/browse") { backStackEntry ->
+        val key = backStackEntry.arguments?.getString("key") ?: return@composable
+        RepositoryBrowseScreen(
+            repoKey = key,
+            onBack = { navController.popBackStack() },
         )
     }
     composable("artifacts/{id}") { backStackEntry ->

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/artifacts/RepositoryBrowseScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/artifacts/RepositoryBrowseScreen.kt
@@ -1,0 +1,309 @@
+package com.artifactkeeper.android.ui.screens.artifacts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.artifactkeeper.android.ui.components.LoadingErrorContainer
+import com.artifactkeeper.android.ui.util.formatBytes
+import com.artifactkeeper.android.ui.util.formatRelativeTime
+import com.artifactkeeper.client.models.ArtifactResponse
+import com.artifactkeeper.client.models.TreeNodeResponse
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RepositoryBrowseScreen(
+    repoKey: String,
+    onBack: () -> Unit,
+    viewModel: RepositoryBrowseViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var pendingDelete by remember { mutableStateOf<TreeNodeResponse?>(null) }
+
+    LaunchedEffect(repoKey) { viewModel.load(repoKey) }
+
+    LaunchedEffect(state.actionError) {
+        state.actionError?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearActionError()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(repoKey) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+    ) { innerPadding ->
+        Column(modifier = Modifier.padding(innerPadding)) {
+            Breadcrumbs(
+                breadcrumbs = state.breadcrumbs,
+                onRoot = { viewModel.navigateToRoot() },
+                onCrumb = { viewModel.navigateToCrumb(it) },
+            )
+            HorizontalDivider()
+
+            LoadingErrorContainer(
+                isLoading = state.isLoading,
+                error = state.error,
+                onRetry = { viewModel.load(repoKey, state.currentPath) },
+            ) {
+                PullToRefreshBox(
+                    isRefreshing = state.isRefreshing,
+                    onRefresh = { viewModel.load(repoKey, state.currentPath, refresh = true) },
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    if (state.nodes.isEmpty()) {
+                        EmptyFolder()
+                    } else {
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            items(state.nodes, key = { it.id }) { node ->
+                                NodeRow(
+                                    node = node,
+                                    onClick = {
+                                        if (node.type == "folder") viewModel.openFolder(node)
+                                        else viewModel.openFile(node)
+                                    },
+                                    onDelete = if (node.type == "folder") null else {
+                                        { pendingDelete = node }
+                                    },
+                                )
+                                HorizontalDivider()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    state.selectedFile?.let { artifact ->
+        FileDetailDialog(
+            artifact = artifact,
+            onDismiss = { viewModel.dismissFile() },
+            onDelete = {
+                viewModel.dismissFile()
+                pendingDelete = TreeNodeResponse(
+                    hasChildren = false,
+                    id = artifact.path,
+                    name = artifact.name,
+                    path = artifact.path,
+                    type = "file",
+                )
+            },
+        )
+    }
+
+    pendingDelete?.let { node ->
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Delete artifact") },
+            text = { Text("Delete ${node.name}? This cannot be undone.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteArtifact(node.path)
+                        pendingDelete = null
+                    },
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun Breadcrumbs(
+    breadcrumbs: List<BrowseCrumb>,
+    onRoot: () -> Unit,
+    onCrumb: (path: String) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onRoot) {
+            Icon(Icons.Filled.Home, contentDescription = "Repository root")
+        }
+        breadcrumbs.forEach { crumb ->
+            Icon(
+                Icons.Filled.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            TextButton(onClick = { onCrumb(crumb.path) }) {
+                Text(crumb.name)
+            }
+        }
+    }
+}
+
+@Composable
+private fun NodeRow(
+    node: TreeNodeResponse,
+    onClick: () -> Unit,
+    onDelete: (() -> Unit)?,
+) {
+    ListItem(
+        modifier = Modifier.clickable(onClick = onClick),
+        headlineContent = { Text(node.name) },
+        supportingContent = {
+            if (node.type == "folder") {
+                Text(node.childrenCount?.let { "$it item${if (it == 1L) "" else "s"}" } ?: "Folder")
+            } else {
+                Text(node.sizeBytes?.let { formatBytes(it) } ?: "File")
+            }
+        },
+        leadingContent = {
+            if (node.type == "folder") {
+                Icon(
+                    Icons.Filled.Folder,
+                    contentDescription = "Folder",
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            } else {
+                Icon(
+                    Icons.AutoMirrored.Filled.InsertDriveFile,
+                    contentDescription = "File",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        trailingContent = {
+            if (onDelete != null) {
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        Icons.Filled.Delete,
+                        contentDescription = "Delete ${node.name}",
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                }
+            } else {
+                Icon(Icons.Filled.ChevronRight, contentDescription = null)
+            }
+        },
+    )
+}
+
+@Composable
+private fun FileDetailDialog(
+    artifact: ArtifactResponse,
+    onDismiss: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(artifact.name) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                MetaRow("Path", artifact.path)
+                artifact.version?.let { MetaRow("Version", it) }
+                MetaRow("Content type", artifact.contentType)
+                MetaRow("Size", formatBytes(artifact.sizeBytes))
+                MetaRow("Downloads", artifact.downloadCount.toString())
+                MetaRow("Created", formatRelativeTime(artifact.createdAt))
+                MetaRow("SHA-256", artifact.checksumSha256, monospace = true)
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDelete) {
+                Text("Delete", color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+    )
+}
+
+@Composable
+private fun MetaRow(label: String, value: String, monospace: Boolean = false) {
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = if (monospace) FontFamily.Monospace else FontFamily.Default,
+        )
+    }
+}
+
+@Composable
+private fun EmptyFolder() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            Icons.Filled.Folder,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = "This folder is empty",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 8.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/artifacts/RepositoryBrowseViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/artifacts/RepositoryBrowseViewModel.kt
@@ -1,0 +1,159 @@
+package com.artifactkeeper.android.ui.screens.artifacts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.ArtifactResponse
+import com.artifactkeeper.client.models.TreeNodeResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/** A single segment of the browse path, used to render breadcrumbs. */
+data class BrowseCrumb(
+    val name: String,
+    val path: String,
+)
+
+data class RepositoryBrowseUiState(
+    val repoKey: String = "",
+    val currentPath: String = "",
+    val nodes: List<TreeNodeResponse> = emptyList(),
+    val breadcrumbs: List<BrowseCrumb> = emptyList(),
+    val selectedFile: ArtifactResponse? = null,
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isActionInProgress: Boolean = false,
+    val error: String? = null,
+    val actionError: String? = null,
+)
+
+@HiltViewModel
+class RepositoryBrowseViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RepositoryBrowseUiState())
+    val uiState: StateFlow<RepositoryBrowseUiState> = _uiState.asStateFlow()
+
+    fun load(repoKey: String, path: String = "", refresh: Boolean = false) {
+        _uiState.update {
+            it.copy(
+                repoKey = repoKey,
+                currentPath = path,
+                breadcrumbs = crumbsFor(path),
+            )
+        }
+        fetchTree(refresh)
+    }
+
+    fun openFolder(node: TreeNodeResponse) {
+        if (node.type != "folder") return
+        load(_uiState.value.repoKey, node.path)
+    }
+
+    fun navigateToCrumb(path: String) {
+        load(_uiState.value.repoKey, path)
+    }
+
+    fun navigateToRoot() {
+        load(_uiState.value.repoKey, "")
+    }
+
+    fun openFile(node: TreeNodeResponse) {
+        if (node.type == "folder") return
+        val repoKey = _uiState.value.repoKey
+        viewModelScope.launch {
+            try {
+                val metadata = apiClient.reposApi
+                    .getRepositoryArtifactMetadata(repoKey, node.path)
+                    .unwrap()
+                _uiState.update { it.copy(selectedFile = metadata, actionError = null) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(actionError = e.message ?: "Failed to load artifact") }
+            }
+        }
+    }
+
+    fun dismissFile() {
+        _uiState.update { it.copy(selectedFile = null) }
+    }
+
+    fun deleteArtifact(path: String) {
+        val repoKey = _uiState.value.repoKey
+        viewModelScope.launch {
+            _uiState.update { it.copy(isActionInProgress = true, actionError = null) }
+            try {
+                apiClient.reposApi.deleteArtifact(repoKey, path).unwrap()
+                _uiState.update { it.copy(isActionInProgress = false, selectedFile = null) }
+                fetchTree(refresh = true)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(isActionInProgress = false, actionError = e.message ?: "Failed to delete artifact")
+                }
+            }
+        }
+    }
+
+    fun clearActionError() {
+        _uiState.update { it.copy(actionError = null) }
+    }
+
+    private fun fetchTree(refresh: Boolean) {
+        val state = _uiState.value
+        val pathArg = state.currentPath.ifBlank { null }
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val response = apiClient.reposApi
+                    .getTree(state.repoKey, pathArg, true)
+                    .unwrap()
+                _uiState.update {
+                    it.copy(
+                        nodes = response.nodes.sortedWith(nodeOrder),
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = null,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        nodes = emptyList(),
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = e.message ?: "Failed to load contents",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun crumbsFor(path: String): List<BrowseCrumb> {
+        if (path.isBlank()) return emptyList()
+        val segments = path.split("/").filter { it.isNotBlank() }
+        val crumbs = mutableListOf<BrowseCrumb>()
+        val builder = StringBuilder()
+        for (segment in segments) {
+            if (builder.isNotEmpty()) builder.append("/")
+            builder.append(segment)
+            crumbs.add(BrowseCrumb(name = segment, path = builder.toString()))
+        }
+        return crumbs
+    }
+
+    private companion object {
+        // Folders first, then files, each alphabetical by name (case-insensitive).
+        val nodeOrder: Comparator<TreeNodeResponse> =
+            compareByDescending<TreeNodeResponse> { it.type == "folder" }
+                .thenBy { it.name.lowercase() }
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
@@ -48,6 +49,7 @@ fun RepositoryDetailScreen(
     repoKey: String,
     onBack: () -> Unit,
     onArtifactClick: (id: String) -> Unit = { },
+    onBrowseFiles: (repoKey: String) -> Unit = { },
     onArtifactSecurityClick: (id: String, name: String) -> Unit = { _, _ -> },
     onNavigateToMembers: ((repoKey: String, repoName: String, repoFormat: String) -> Unit)? = null,
 ) {
@@ -155,6 +157,9 @@ fun RepositoryDetailScreen(
                 }
             },
             actions = {
+                IconButton(onClick = { onBrowseFiles(repoKey) }) {
+                    Icon(Icons.Default.Folder, contentDescription = "Browse files")
+                }
                 if (!isUploading) {
                     IconButton(onClick = { filePickerLauncher.launch("*/*") }) {
                         Icon(Icons.Default.Upload, contentDescription = "Upload Artifact")

--- a/app/src/test/java/com/artifactkeeper/android/RepositoryBrowseViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/RepositoryBrowseViewModelTest.kt
@@ -1,0 +1,250 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.artifacts.RepositoryBrowseUiState
+import com.artifactkeeper.android.ui.screens.artifacts.RepositoryBrowseViewModel
+import com.artifactkeeper.client.apis.RepositoriesApi
+import com.artifactkeeper.client.models.ArtifactResponse
+import com.artifactkeeper.client.models.TreeNodeResponse
+import com.artifactkeeper.client.models.TreeResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RepositoryBrowseViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockReposApi = mockk<RepositoriesApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { reposApi } returns mockReposApi
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is empty`() {
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        assertEquals(RepositoryBrowseUiState(), vm.uiState.value)
+        assertTrue(vm.uiState.value.nodes.isEmpty())
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `load populates nodes for the repository root`() {
+        coEvery { mockReposApi.getTree("maven-local", null, true) } returns
+            Response.success(tree(folder("com"), file("readme.txt", "readme.txt")))
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+
+        vm.load("maven-local")
+
+        val state = vm.uiState.value
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertEquals("maven-local", state.repoKey)
+        assertEquals("", state.currentPath)
+        assertEquals(2, state.nodes.size)
+    }
+
+    @Test
+    fun `load sorts folders before files`() {
+        coEvery { mockReposApi.getTree(any(), any(), any()) } returns
+            Response.success(tree(file("a.txt", "a.txt"), folder("zeta"), file("b.txt", "b.txt")))
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+
+        vm.load("maven-local")
+
+        val nodes = vm.uiState.value.nodes
+        assertEquals("zeta", nodes.first().name)
+        assertEquals("folder", nodes.first().type)
+    }
+
+    @Test
+    fun `openFolder browses into the folder path`() {
+        coEvery { mockReposApi.getTree("maven-local", null, true) } returns
+            Response.success(tree(folder("com")))
+        coEvery { mockReposApi.getTree("maven-local", "com", true) } returns
+            Response.success(tree(folder("com/example")))
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        vm.load("maven-local")
+
+        vm.openFolder(folder("com"))
+
+        val state = vm.uiState.value
+        assertEquals("com", state.currentPath)
+        assertEquals(1, state.nodes.size)
+        assertEquals("com/example", state.nodes.first().path)
+    }
+
+    @Test
+    fun `breadcrumbs reflect the current path`() {
+        coEvery { mockReposApi.getTree(any(), any(), any()) } returns Response.success(tree())
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        vm.load("maven-local")
+
+        vm.openFolder(folder("com", path = "com"))
+        vm.openFolder(folder("example", path = "com/example"))
+
+        val crumbs = vm.uiState.value.breadcrumbs
+        assertEquals(listOf("com", "example"), crumbs.map { it.name })
+        assertEquals(listOf("com", "com/example"), crumbs.map { it.path })
+    }
+
+    @Test
+    fun `navigateToCrumb truncates the path and reloads`() {
+        coEvery { mockReposApi.getTree(any(), any(), any()) } returns Response.success(tree())
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        vm.load("maven-local")
+        vm.openFolder(folder("com", path = "com"))
+        vm.openFolder(folder("example", path = "com/example"))
+
+        vm.navigateToCrumb("com")
+
+        assertEquals("com", vm.uiState.value.currentPath)
+        assertEquals(listOf("com"), vm.uiState.value.breadcrumbs.map { it.path })
+    }
+
+    @Test
+    fun `navigateToRoot clears the path`() {
+        coEvery { mockReposApi.getTree(any(), any(), any()) } returns Response.success(tree())
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        vm.load("maven-local")
+        vm.openFolder(folder("com", path = "com"))
+
+        vm.navigateToRoot()
+
+        assertEquals("", vm.uiState.value.currentPath)
+        assertTrue(vm.uiState.value.breadcrumbs.isEmpty())
+    }
+
+    @Test
+    fun `openFile fetches artifact metadata`() {
+        coEvery { mockReposApi.getTree(any(), any(), any()) } returns Response.success(tree())
+        coEvery { mockReposApi.getRepositoryArtifactMetadata("maven-local", "com/app.jar") } returns
+            Response.success(artifact("app.jar", "com/app.jar"))
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        vm.load("maven-local")
+
+        vm.openFile(file("app.jar", "com/app.jar"))
+
+        assertEquals("app.jar", vm.uiState.value.selectedFile?.name)
+        coVerify { mockReposApi.getRepositoryArtifactMetadata("maven-local", "com/app.jar") }
+    }
+
+    @Test
+    fun `dismissFile clears the selected file`() {
+        coEvery { mockReposApi.getTree(any(), any(), any()) } returns Response.success(tree())
+        coEvery { mockReposApi.getRepositoryArtifactMetadata(any(), any()) } returns
+            Response.success(artifact("app.jar", "com/app.jar"))
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        vm.load("maven-local")
+        vm.openFile(file("app.jar", "com/app.jar"))
+
+        vm.dismissFile()
+
+        assertNull(vm.uiState.value.selectedFile)
+    }
+
+    @Test
+    fun `deleteArtifact deletes and reloads the current folder`() {
+        coEvery { mockReposApi.getTree("maven-local", null, true) } returnsMany listOf(
+            Response.success(tree(file("old.jar", "old.jar"))),
+            Response.success(tree()),
+        )
+        coEvery { mockReposApi.deleteArtifact("maven-local", "old.jar") } returns Response.success(Unit)
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        vm.load("maven-local")
+
+        vm.deleteArtifact("old.jar")
+
+        coVerify { mockReposApi.deleteArtifact("maven-local", "old.jar") }
+        assertTrue(vm.uiState.value.nodes.isEmpty())
+    }
+
+    @Test
+    fun `deleteArtifact surfaces an error and keeps nodes`() {
+        coEvery { mockReposApi.getTree("maven-local", null, true) } returns
+            Response.success(tree(file("old.jar", "old.jar")))
+        coEvery { mockReposApi.deleteArtifact("maven-local", "old.jar") } returns Response.error(500, errorBody())
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+        vm.load("maven-local")
+
+        vm.deleteArtifact("old.jar")
+
+        assertEquals(true, vm.uiState.value.actionError?.isNotBlank())
+        assertEquals(1, vm.uiState.value.nodes.size)
+    }
+
+    @Test
+    fun `load sets error when the tree call fails`() {
+        coEvery { mockReposApi.getTree(any(), any(), any()) } returns Response.error(404, errorBody())
+        val vm = RepositoryBrowseViewModel(mockApiClient)
+
+        vm.load("missing")
+
+        assertEquals(true, vm.uiState.value.error?.isNotBlank())
+        assertTrue(vm.uiState.value.nodes.isEmpty())
+    }
+
+    // Helpers
+
+    private fun tree(vararg nodes: TreeNodeResponse) = TreeResponse(nodes = nodes.toList())
+
+    private fun folder(name: String, path: String = name) = TreeNodeResponse(
+        hasChildren = true,
+        id = path,
+        name = name,
+        path = path,
+        type = "folder",
+        childrenCount = 1,
+    )
+
+    private fun file(name: String, path: String) = TreeNodeResponse(
+        hasChildren = false,
+        id = path,
+        name = name,
+        path = path,
+        type = "file",
+        sizeBytes = 1024,
+    )
+
+    private fun artifact(name: String, path: String) = ArtifactResponse(
+        checksumSha256 = "abc",
+        contentType = "application/octet-stream",
+        createdAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+        downloadCount = 0,
+        id = UUID.randomUUID(),
+        name = name,
+        path = path,
+        repositoryKey = "maven-local",
+        sizeBytes = 1024,
+    )
+
+    private fun errorBody() = "{\"error\":\"boom\"}".toResponseBody("application/json".toMediaType())
+}


### PR DESCRIPTION
## Summary
Adds a file-tree browser for repositories (Artifacts cluster 2). Users can navigate folders via breadcrumbs, tap a file to view its metadata, and delete artifacts with a confirmation dialog.

Covered operations: `get_tree`, `get_repository_artifact_metadata`, `delete_artifact`.

Deferred:
- `get_content` (GET /api/v1/tree/content): the generated Kotlin client types it as `Response<Unit>` with no readable body, so an in-app content preview is not possible through the SDK. Deferred until the client exposes the raw body or a download/streaming wave handles it.
- Raw upload (PUT bytes) and chunked upload sessions remain out of mobile scope per the agreed rulings.

Implementation:
- `RepositoryBrowseViewModel` (Hilt) loads the tree per path, sorts folders before files, tracks breadcrumb state, fetches artifact metadata on file tap, and deletes artifacts then reloads.
- `RepositoryBrowseScreen` (Material 3) renders breadcrumbs, folder/file `ListItem` rows with icons, a file metadata dialog, a delete confirmation dialog, and shared loading/error/empty states with pull-to-refresh.
- Navigation: `repos/{key}/browse` route, reached from a Browse files action added to the repository detail toolbar.

Closes #92
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New: `RepositoryBrowseViewModelTest` (12 tests) covering root load, folder-before-file sort, folder navigation, breadcrumb building, navigate-to-crumb and navigate-to-root, file metadata fetch, dismiss, delete with reload, delete error handling, and tree load error. Full unit suite green: 698 tests, 0 failures. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both pass.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes