### PR TITLE
feat(security): CVE tracking and findings acknowledgment

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -58,6 +58,8 @@ import com.artifactkeeper.android.ui.screens.repositories.RepositoryDetailScreen
 import com.artifactkeeper.android.ui.screens.repositories.VirtualMembersScreen
 import com.artifactkeeper.android.ui.screens.search.SearchScreen
 import com.artifactkeeper.android.ui.screens.security.ArtifactSecurityScreen
+import com.artifactkeeper.android.ui.screens.security.CveDetailScreen
+import com.artifactkeeper.android.ui.screens.security.CveTrackingScreen
 import com.artifactkeeper.android.ui.screens.security.DependencyTrackScreen
 import com.artifactkeeper.android.ui.screens.security.DtProjectDetailScreen
 import com.artifactkeeper.android.ui.screens.security.LicensePoliciesScreen
@@ -733,6 +735,7 @@ private fun NavGraphBuilder.detailRoutes(navController: NavHostController) {
         ArtifactSecurityScreen(
             artifactId = id,
             onScanClick = { scanId -> navController.navigate("artifacts/$id/security/scans/$scanId") },
+            onViewCves = { navController.navigate("artifacts/$id/cves") },
             onBack = { navController.popBackStack() },
         )
     }
@@ -740,6 +743,25 @@ private fun NavGraphBuilder.detailRoutes(navController: NavHostController) {
         val scanId = backStackEntry.arguments?.getString("scanId") ?: return@composable
         ScanDetailScreen(
             scanId = scanId,
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable("artifacts/{id}/cves") { backStackEntry ->
+        val id = backStackEntry.arguments?.getString("id") ?: return@composable
+        CveTrackingScreen(
+            artifactId = id,
+            onCveClick = { artifactId, cveId ->
+                navController.navigate("artifacts/$artifactId/cves/$cveId")
+            },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable("artifacts/{id}/cves/{cveId}") { backStackEntry ->
+        val id = backStackEntry.arguments?.getString("id") ?: return@composable
+        val cveId = backStackEntry.arguments?.getString("cveId") ?: return@composable
+        CveDetailScreen(
+            artifactId = id,
+            cveId = cveId,
             onBack = { navController.popBackStack() },
         )
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityScreen.kt
@@ -50,6 +50,7 @@ fun ArtifactSecurityScreen(
     artifactId: String,
     onScanClick: (String) -> Unit,
     onBack: () -> Unit,
+    onViewCves: () -> Unit = {},
     viewModel: ArtifactSecurityViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -68,6 +69,11 @@ fun ArtifactSecurityScreen(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
                     )
+                }
+            },
+            actions = {
+                TextButton(onClick = onViewCves) {
+                    Text("CVEs")
                 }
             },
         )

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/CveTrackingScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/CveTrackingScreen.kt
@@ -1,0 +1,407 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.android.ui.theme.Critical
+import com.artifactkeeper.android.ui.theme.High
+import com.artifactkeeper.android.ui.theme.Low
+import com.artifactkeeper.android.ui.theme.Medium
+import com.artifactkeeper.client.models.CveHistoryEntry
+import java.util.UUID
+
+private val StatusOpen = Color(0xFFF5222D)
+private val StatusAck = Color(0xFFFAAD14)
+private val StatusFixed = Color(0xFF52C41A)
+
+/** CVE workflow statuses offered in the status update dialog. */
+private val CveStatuses = listOf("open", "acknowledged", "false_positive", "fixed")
+
+/**
+ * Lists the CVE history entries detected for an artifact, ordered most severe
+ * first. Tapping a CVE opens [CveDetailScreen].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CveTrackingScreen(
+    artifactId: String,
+    onCveClick: (artifactId: String, cveId: String) -> Unit,
+    onBack: () -> Unit,
+    viewModel: CveTrackingViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val parsedId = remember(artifactId) { runCatching { UUID.fromString(artifactId) }.getOrNull() }
+
+    LaunchedEffect(parsedId) {
+        parsedId?.let { viewModel.loadArtifactCves(it) }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("CVE Tracking") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            },
+        )
+
+        when {
+            parsedId == null -> CenteredText("Invalid artifact id")
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.error != null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.loadArtifactCves(parsedId, refresh = true) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            state.entries.isEmpty() -> CenteredText("No CVEs detected for this artifact")
+            else -> {
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    items(state.entries, key = { it.id }) { entry ->
+                        CveEntryCard(
+                            entry = entry,
+                            onClick = { onCveClick(artifactId, entry.cveId) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CveEntryCard(entry: CveHistoryEntry, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    entry.severity?.let { SeverityBadge(it) }
+                    Text(
+                        text = entry.cveId,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                CveStatusBadge(entry.status)
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    imageVector = Icons.Default.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            val details = buildList {
+                entry.cvssScore?.let { add("CVSS ${"%.1f".format(it)}") }
+                entry.affectedComponent?.takeIf { it.isNotBlank() }?.let { comp ->
+                    add(comp + (entry.affectedVersion?.let { " $it" } ?: ""))
+                }
+                entry.fixedVersion?.takeIf { it.isNotBlank() }?.let { add("fixed in $it") }
+            }
+            if (details.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = details.joinToString("  -  "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Detail for a single CVE: its detection history for the artifact plus a status
+ * update action (acknowledge, mark fixed, mark false positive).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CveDetailScreen(
+    artifactId: String,
+    cveId: String,
+    onBack: () -> Unit,
+    viewModel: CveTrackingViewModel = hiltViewModel(),
+) {
+    val state by viewModel.cveDetailState.collectAsState()
+    val parsedId = remember(artifactId) { runCatching { UUID.fromString(artifactId) }.getOrNull() }
+    val uriHandler = LocalUriHandler.current
+    var showStatusDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(parsedId, cveId) {
+        parsedId?.let { viewModel.loadCveDetail(it, cveId) }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text(cveId) },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            },
+            actions = {
+                TextButton(
+                    onClick = { showStatusDialog = true },
+                    enabled = parsedId != null && !state.isUpdating,
+                ) {
+                    Text("Update status")
+                }
+            },
+        )
+
+        when {
+            parsedId == null -> CenteredText("Invalid artifact id")
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            else -> {
+                state.error?.let { err ->
+                    Text(
+                        text = err,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    )
+                }
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    item {
+                        Text(
+                            text = cveId,
+                            style = MaterialTheme.typography.bodySmall.copy(
+                                textDecoration = TextDecoration.Underline,
+                            ),
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.clickable {
+                                uriHandler.openUri("https://nvd.nist.gov/vuln/detail/$cveId")
+                            },
+                        )
+                    }
+                    if (state.history.isEmpty()) {
+                        item { CenteredText("No history for this CVE") }
+                    } else {
+                        items(state.history, key = { it.id }) { entry ->
+                            CveHistoryCard(entry)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showStatusDialog && parsedId != null) {
+        CveStatusDialog(
+            isUpdating = state.isUpdating,
+            onDismiss = { showStatusDialog = false },
+            onConfirm = { status, reason ->
+                viewModel.updateCveStatus(parsedId, cveId, status, reason)
+                showStatusDialog = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun CveHistoryCard(entry: CveHistoryEntry) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                entry.severity?.let { SeverityBadge(it) } ?: Spacer(Modifier.width(0.dp))
+                CveStatusBadge(entry.status)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            entry.cvssScore?.let {
+                Text(
+                    text = "CVSS ${"%.1f".format(it)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = "First detected ${entry.firstDetectedAt.toLocalDate()}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "Last detected ${entry.lastDetectedAt.toLocalDate()}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            entry.acknowledgedReason?.takeIf { it.isNotBlank() }?.let { reason ->
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = "Reason: $reason",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CveStatusDialog(
+    isUpdating: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (status: String, reason: String?) -> Unit,
+) {
+    var selectedStatus by remember { mutableStateOf(CveStatuses.first()) }
+    var reason by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Update CVE status") },
+        text = {
+            Column {
+                CveStatuses.forEach { status ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { selectedStatus = status }
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = selectedStatus == status,
+                            onClick = { selectedStatus = status },
+                        )
+                        Text(status.replace('_', ' ').replaceFirstChar { it.uppercase() })
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = reason,
+                    onValueChange = { reason = it },
+                    label = { Text("Reason (optional)") },
+                    singleLine = false,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(selectedStatus, reason.ifBlank { null }) },
+                enabled = !isUpdating,
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}
+
+@Composable
+private fun SeverityBadge(severity: String) {
+    val color = when (severity.lowercase()) {
+        "critical" -> Critical
+        "high" -> High
+        "medium" -> Medium
+        "low" -> Low
+        else -> Low
+    }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = severity.replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+private fun CveStatusBadge(status: String) {
+    val color = when (status.lowercase()) {
+        "open" -> StatusOpen
+        "acknowledged", "false_positive" -> StatusAck
+        "fixed", "resolved" -> StatusFixed
+        else -> StatusAck
+    }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = status.replace('_', ' ').replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+private fun CenteredText(text: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/CveTrackingViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/CveTrackingViewModel.kt
@@ -1,0 +1,164 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.AcknowledgeRequest
+import com.artifactkeeper.client.models.CveHistoryEntry
+import com.artifactkeeper.client.models.ScanConfigResponse
+import com.artifactkeeper.client.models.UpdateCveStatusRequest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for the CVE tracking list: the CVE history entries for an artifact plus
+ * the server's scan configuration.
+ */
+data class CveTrackingUiState(
+    val entries: List<CveHistoryEntry> = emptyList(),
+    val scanConfigs: List<ScanConfigResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+)
+
+/**
+ * State for a single CVE: its detection/status history across an artifact, and
+ * an in-flight flag while a status update is being applied.
+ */
+data class CveDetailUiState(
+    val history: List<CveHistoryEntry> = emptyList(),
+    val isLoading: Boolean = false,
+    val isUpdating: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class CveTrackingViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CveTrackingUiState())
+    val uiState: StateFlow<CveTrackingUiState> = _uiState.asStateFlow()
+
+    private val _cveDetailState = MutableStateFlow(CveDetailUiState())
+    val cveDetailState: StateFlow<CveDetailUiState> = _cveDetailState.asStateFlow()
+
+    fun loadArtifactCves(artifactId: UUID, refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val entries = apiClient.sbomApi.getCveHistoryByArtifact(artifactId).unwrap()
+                    .sortedBy { cveSeverityRank(it.severity) }
+                _uiState.update {
+                    it.copy(entries = entries, isLoading = false, isRefreshing = false)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load CVE history",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun loadScanConfigs() {
+        viewModelScope.launch {
+            try {
+                val configs = apiClient.securityApi.listScanConfigs().unwrap()
+                _uiState.update { it.copy(scanConfigs = configs) }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message ?: "Failed to load scan configs") }
+            }
+        }
+    }
+
+    fun loadCveDetail(artifactId: UUID, cveId: String) {
+        viewModelScope.launch {
+            _cveDetailState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val history = apiClient.sbomApi.getCveHistoryByCve(cveId).unwrap()
+                    .filter { it.artifactId == artifactId }
+                    .ifEmpty { apiClient.sbomApi.getCveHistoryByCve(cveId).unwrap() }
+                _cveDetailState.update { it.copy(history = history, isLoading = false) }
+            } catch (e: Exception) {
+                _cveDetailState.update {
+                    it.copy(error = e.message ?: "Failed to load CVE detail", isLoading = false)
+                }
+            }
+        }
+    }
+
+    fun updateCveStatus(artifactId: UUID, cveId: String, status: String, reason: String?) {
+        viewModelScope.launch {
+            _cveDetailState.update { it.copy(isUpdating = true, error = null) }
+            try {
+                apiClient.sbomApi.updateCveStatusByArtifactCve(
+                    artifactId,
+                    cveId,
+                    UpdateCveStatusRequest(status = status, reason = reason),
+                ).unwrap()
+                val history = apiClient.sbomApi.getCveHistoryByCve(cveId).unwrap()
+                _cveDetailState.update { it.copy(history = history, isUpdating = false) }
+            } catch (e: Exception) {
+                _cveDetailState.update {
+                    it.copy(error = e.message ?: "Failed to update CVE status", isUpdating = false)
+                }
+            }
+        }
+    }
+
+    fun acknowledgeFinding(findingId: UUID, reason: String) {
+        viewModelScope.launch {
+            try {
+                apiClient.securityApi.acknowledgeFinding(
+                    findingId,
+                    AcknowledgeRequest(reason = reason),
+                ).unwrap()
+                _uiState.update { it.copy(message = "Finding acknowledged") }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message ?: "Failed to acknowledge finding") }
+            }
+        }
+    }
+
+    fun revokeAcknowledgment(findingId: UUID) {
+        viewModelScope.launch {
+            try {
+                apiClient.securityApi.revokeAcknowledgment(findingId).unwrap()
+                _uiState.update { it.copy(message = "Acknowledgment revoked") }
+            } catch (e: Exception) {
+                _uiState.update { it.copy(error = e.message ?: "Failed to revoke acknowledgment") }
+            }
+        }
+    }
+
+    fun clearMessage() {
+        _uiState.update { it.copy(message = null, error = null) }
+    }
+
+    companion object {
+        /** Lower rank sorts first, so critical CVEs appear at the top; unknown last. */
+        fun cveSeverityRank(severity: String?): Int = when (severity?.lowercase()) {
+            "critical" -> 0
+            "high" -> 1
+            "medium" -> 2
+            "low" -> 3
+            else -> 4
+        }
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/CveTrackingViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/CveTrackingViewModelTest.kt
@@ -1,0 +1,269 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.security.CveDetailUiState
+import com.artifactkeeper.android.ui.screens.security.CveTrackingUiState
+import com.artifactkeeper.android.ui.screens.security.CveTrackingViewModel
+import com.artifactkeeper.client.apis.SbomApi
+import com.artifactkeeper.client.apis.SecurityApi
+import com.artifactkeeper.client.models.CveHistoryEntry
+import com.artifactkeeper.client.models.FindingResponse
+import com.artifactkeeper.client.models.ScanConfigResponse
+import com.artifactkeeper.client.models.UpdateCveStatusRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CveTrackingViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockSecurityApi = mockk<SecurityApi>()
+    private val mockSbomApi = mockk<SbomApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { securityApi } returns mockSecurityApi
+        every { sbomApi } returns mockSbomApi
+    }
+
+    private val artifactId = UUID.randomUUID()
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun cve(
+        cveId: String,
+        status: String = "open",
+        severity: String? = "high",
+        score: Double? = 7.5,
+    ) = CveHistoryEntry(
+        artifactId = artifactId,
+        createdAt = now,
+        cveId = cveId,
+        firstDetectedAt = now,
+        id = UUID.randomUUID(),
+        lastDetectedAt = now,
+        status = status,
+        updatedAt = now,
+        cvssScore = score,
+        severity = severity,
+    )
+
+    private fun finding() = FindingResponse(
+        artifactId = artifactId,
+        createdAt = now,
+        id = UUID.randomUUID(),
+        isAcknowledged = false,
+        scanResultId = UUID.randomUUID(),
+        severity = "high",
+        title = "Some vuln",
+    )
+
+    private fun scanConfig() = ScanConfigResponse(
+        blockOnPolicyViolation = true,
+        createdAt = now,
+        id = UUID.randomUUID(),
+        repositoryId = UUID.randomUUID(),
+        scanEnabled = true,
+        scanOnProxy = false,
+        scanOnUpload = true,
+        severityThreshold = "high",
+        updatedAt = now,
+    )
+
+    // =========================================================================
+    // UI state
+    // =========================================================================
+
+    @Test
+    fun `initial tracking state is empty`() {
+        val state = CveTrackingUiState()
+        assertTrue(state.entries.isEmpty())
+        assertTrue(state.scanConfigs.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `initial detail state is empty`() {
+        val state = CveDetailUiState()
+        assertTrue(state.history.isEmpty())
+        assertFalse(state.isLoading)
+        assertFalse(state.isUpdating)
+        assertNull(state.error)
+    }
+
+    // =========================================================================
+    // loadArtifactCves
+    // =========================================================================
+
+    @Test
+    fun `loadArtifactCves populates entries sorted by severity`() = runTest {
+        coEvery { mockSbomApi.getCveHistoryByArtifact(artifactId) } returns Response.success(
+            listOf(
+                cve("CVE-1", severity = "low", score = 3.0),
+                cve("CVE-2", severity = "critical", score = 9.8),
+                cve("CVE-3", severity = "medium", score = 5.0),
+            ),
+        )
+
+        val vm = CveTrackingViewModel(mockApiClient)
+        vm.loadArtifactCves(artifactId)
+
+        val severities = vm.uiState.value.entries.map { it.severity }
+        assertEquals(listOf("critical", "medium", "low"), severities)
+        assertFalse(vm.uiState.value.isLoading)
+        assertNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `loadArtifactCves sets error on failure`() = runTest {
+        coEvery { mockSbomApi.getCveHistoryByArtifact(artifactId) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = CveTrackingViewModel(mockApiClient)
+        vm.loadArtifactCves(artifactId)
+
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    // =========================================================================
+    // loadCveDetail
+    // =========================================================================
+
+    @Test
+    fun `loadCveDetail populates history for a cve`() = runTest {
+        coEvery { mockSbomApi.getCveHistoryByCve("CVE-2") } returns Response.success(
+            listOf(cve("CVE-2"), cve("CVE-2")),
+        )
+
+        val vm = CveTrackingViewModel(mockApiClient)
+        vm.loadCveDetail(artifactId, "CVE-2")
+
+        assertEquals(2, vm.cveDetailState.value.history.size)
+        assertFalse(vm.cveDetailState.value.isLoading)
+    }
+
+    // =========================================================================
+    // updateCveStatus
+    // =========================================================================
+
+    @Test
+    fun `updateCveStatus sends request and reloads history`() = runTest {
+        coEvery {
+            mockSbomApi.updateCveStatusByArtifactCve(artifactId, "CVE-2", any())
+        } returns Response.success(cve("CVE-2", status = "acknowledged"))
+        coEvery { mockSbomApi.getCveHistoryByCve("CVE-2") } returns Response.success(
+            listOf(cve("CVE-2", status = "acknowledged")),
+        )
+
+        val vm = CveTrackingViewModel(mockApiClient)
+        vm.updateCveStatus(artifactId, "CVE-2", "acknowledged", "false positive")
+
+        coVerify {
+            mockSbomApi.updateCveStatusByArtifactCve(
+                artifactId,
+                "CVE-2",
+                UpdateCveStatusRequest(status = "acknowledged", reason = "false positive"),
+            )
+        }
+        assertFalse(vm.cveDetailState.value.isUpdating)
+        assertEquals(1, vm.cveDetailState.value.history.size)
+    }
+
+    @Test
+    fun `updateCveStatus sets error on failure`() = runTest {
+        coEvery {
+            mockSbomApi.updateCveStatusByArtifactCve(artifactId, "CVE-2", any())
+        } returns Response.error(400, okhttp3.ResponseBody.create(null, "bad status"))
+
+        val vm = CveTrackingViewModel(mockApiClient)
+        vm.updateCveStatus(artifactId, "CVE-2", "bogus", null)
+
+        assertNotNull(vm.cveDetailState.value.error)
+        assertFalse(vm.cveDetailState.value.isUpdating)
+    }
+
+    // =========================================================================
+    // acknowledgeFinding / revokeAcknowledgment
+    // =========================================================================
+
+    @Test
+    fun `acknowledgeFinding calls api with reason`() = runTest {
+        val findingId = UUID.randomUUID()
+        coEvery { mockSecurityApi.acknowledgeFinding(findingId, any()) } returns
+            Response.success(finding())
+
+        val vm = CveTrackingViewModel(mockApiClient)
+        vm.acknowledgeFinding(findingId, "accepted risk")
+
+        coVerify { mockSecurityApi.acknowledgeFinding(findingId, any()) }
+        assertNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `revokeAcknowledgment calls api`() = runTest {
+        val findingId = UUID.randomUUID()
+        coEvery { mockSecurityApi.revokeAcknowledgment(findingId) } returns
+            Response.success(finding())
+
+        val vm = CveTrackingViewModel(mockApiClient)
+        vm.revokeAcknowledgment(findingId)
+
+        coVerify { mockSecurityApi.revokeAcknowledgment(findingId) }
+    }
+
+    // =========================================================================
+    // loadScanConfigs
+    // =========================================================================
+
+    @Test
+    fun `loadScanConfigs populates configs`() = runTest {
+        coEvery { mockSecurityApi.listScanConfigs() } returns Response.success(
+            listOf(scanConfig(), scanConfig()),
+        )
+
+        val vm = CveTrackingViewModel(mockApiClient)
+        vm.loadScanConfigs()
+
+        assertEquals(2, vm.uiState.value.scanConfigs.size)
+    }
+
+    @Test
+    fun `cveSeverityRank orders critical before low`() {
+        assertTrue(
+            CveTrackingViewModel.cveSeverityRank("critical") <
+                CveTrackingViewModel.cveSeverityRank("low"),
+        )
+        assertTrue(
+            CveTrackingViewModel.cveSeverityRank(null) >
+                CveTrackingViewModel.cveSeverityRank("high"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds CVE tracking and finding triage actions to the Security section, building on the per-artifact security screen (#89) and Dependency-Track work (#91).

- `CveTrackingScreen` (reachable via a "CVEs" action on `ArtifactSecurityScreen`) lists the CVE history entries detected for an artifact, ordered most severe first, each showing severity, status, CVSS, and affected/fixed version.
- `CveDetailScreen` shows the detection history for a CVE and an "Update status" action (open / acknowledged / false positive / fixed, with an optional reason), plus a clickable NVD link.
- `CveTrackingViewModel` is Hilt-injected and backs both screens, with empty/loading/error states. It also exposes finding acknowledge/revoke actions and a scan-config read.

Rebased onto current main (after #89 and #91 landed). Kept all nav routes/sub-tabs; the CVE entry point is on `ArtifactSecurityScreen` (which replaced `SbomScreen` as the per-artifact security screen). No parity-matrix edits (maintained centrally).

Operations wired (previously missing):
- `get_cve_history_by_artifact` (GET /api/v1/sbom/cve/history/by-artifact/{artifact_id})
- `get_cve_history_by_cve` (GET /api/v1/sbom/cve/history/by-cve/{cve_id})
- `update_cve_status_by_artifact_cve` (POST /api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id})
- `acknowledge_finding` (POST /api/v1/security/findings/{id}/acknowledge)
- `revoke_acknowledgment` (DELETE /api/v1/security/findings/{id}/acknowledge)
- `list_scan_configs` (GET /api/v1/security/configs)

Closes #94
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`CveTrackingViewModelTest`: 11 tests, all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both green post-rebase.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes