### PR TITLE
feat(security): repository security view and dashboard summary

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -65,6 +65,7 @@ import com.artifactkeeper.android.ui.screens.security.DependencyTrackScreen
 import com.artifactkeeper.android.ui.screens.security.DtProjectDetailScreen
 import com.artifactkeeper.android.ui.screens.security.LicensePoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.PoliciesScreen
+import com.artifactkeeper.android.ui.screens.security.RepoSecurityScreen
 import com.artifactkeeper.android.ui.screens.security.ScanDetailScreen
 import com.artifactkeeper.android.ui.screens.security.ScansScreen
 import com.artifactkeeper.android.ui.screens.security.SecurityScreen
@@ -709,6 +710,18 @@ private fun NavGraphBuilder.detailRoutes(navController: NavHostController) {
             onNavigateToMembers = { repoKey, repoName, repoFormat ->
                 navController.navigate("repos/$repoKey/members?name=$repoName&format=$repoFormat")
             },
+            onNavigateToRepoSecurity = { repoKey, repoName ->
+                navController.navigate("repos/$repoKey/security?name=$repoName")
+            },
+        )
+    }
+    composable("repos/{key}/security?name={name}") { backStackEntry ->
+        val key = backStackEntry.arguments?.getString("key") ?: return@composable
+        val name = backStackEntry.arguments?.getString("name") ?: key
+        RepoSecurityScreen(
+            repoKey = key,
+            repoName = name,
+            onBack = { navController.popBackStack() },
         )
     }
     composable("repos/{key}/browse") { backStackEntry ->

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
@@ -52,6 +52,7 @@ fun RepositoryDetailScreen(
     onBrowseFiles: (repoKey: String) -> Unit = { },
     onArtifactSecurityClick: (id: String, name: String) -> Unit = { _, _ -> },
     onNavigateToMembers: ((repoKey: String, repoName: String, repoFormat: String) -> Unit)? = null,
+    onNavigateToRepoSecurity: ((repoKey: String, repoName: String) -> Unit)? = null,
 ) {
     var repository by remember { mutableStateOf<Repository?>(null) }
     var artifacts by remember { mutableStateOf<List<Artifact>>(emptyList()) }
@@ -228,6 +229,17 @@ fun RepositoryDetailScreen(
                                     VirtualMembersCard(
                                         onClick = {
                                             onNavigateToMembers?.invoke(repo.key, repo.name, repo.format)
+                                        },
+                                    )
+                                }
+                            }
+
+                            // Repository security card
+                            if (onNavigateToRepoSecurity != null) {
+                                item(key = "repo-security") {
+                                    RepoSecurityCard(
+                                        onClick = {
+                                            onNavigateToRepoSecurity.invoke(repo.key, repo.name)
                                         },
                                     )
                                 }
@@ -544,6 +556,46 @@ private fun VirtualMembersCard(onClick: () -> Unit) {
                 )
                 Text(
                     text = "Manage local and remote repositories included in this virtual repository",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = "Navigate",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RepoSecurityCard(onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.Shield,
+                contentDescription = "Security",
+                modifier = Modifier.size(24.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Security",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = "View this repository's security score, scan configuration, and scans",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/RepoSecurityScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/RepoSecurityScreen.kt
@@ -1,0 +1,388 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.android.ui.theme.Critical
+import com.artifactkeeper.android.ui.theme.High
+import com.artifactkeeper.android.ui.theme.Low
+import com.artifactkeeper.android.ui.theme.Medium
+import com.artifactkeeper.client.models.DashboardResponse
+import com.artifactkeeper.client.models.ScanConfigResponse
+import com.artifactkeeper.client.models.ScanResponse
+import com.artifactkeeper.client.models.ScoreResponse
+
+private val GradeA = Color(0xFF52C41A)
+private val GradeB = Color(0xFF36CFC9)
+private val GradeC = Color(0xFFFAAD14)
+private val GradeD = Color(0xFFFA8C16)
+private val GradeF = Color(0xFFF5222D)
+private val ScanCompleted = Color(0xFF52C41A)
+private val ScanRunning = Color(0xFF1890FF)
+private val ScanFailed = Color(0xFFF5222D)
+private val ScanPending = Color(0xFFFAAD14)
+
+/**
+ * Per-repository security view: the portfolio dashboard summary, this repo's
+ * security score and scan configuration, and the scans run against it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RepoSecurityScreen(
+    repoKey: String,
+    repoName: String,
+    onBack: () -> Unit,
+    viewModel: RepoSecurityViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val dashboardState by viewModel.dashboardState.collectAsState()
+
+    LaunchedEffect(repoKey) {
+        viewModel.loadRepoSecurity(repoKey)
+        viewModel.loadDashboard()
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = {
+                Column {
+                    Text("Repository Security")
+                    Text(
+                        text = repoName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            },
+        )
+
+        when {
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.error != null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.loadRepoSecurity(repoKey, refresh = true) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            else -> {
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    dashboardState.dashboard?.let { dashboard ->
+                        item { SecurityDashboardCard(dashboard) }
+                    }
+
+                    item {
+                        Text(
+                            text = "This Repository",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+
+                    state.score?.let { score ->
+                        item { RepoScoreCard(score) }
+                    }
+                    state.config?.let { config ->
+                        item { ScanConfigCard(config) }
+                    }
+                    if (state.score == null && state.config == null) {
+                        item {
+                            Text(
+                                text = "No security data configured for this repository",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+
+                    item {
+                        Text(
+                            text = "Scans (${state.scans.size})",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
+                    if (state.scans.isEmpty()) {
+                        item {
+                            Text(
+                                text = "No scans run against this repository",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        items(state.scans, key = { it.id }) { scan ->
+                            RepoScanRow(scan)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Portfolio-level security summary. Reusable from the Security dashboard tab.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun SecurityDashboardCard(dashboard: DashboardResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Security Overview",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                DashboardMetric("Critical", dashboard.criticalFindings, Critical)
+                DashboardMetric("High", dashboard.highFindings, High)
+                DashboardMetric("Findings", dashboard.totalFindings, Medium)
+                DashboardMetric("Scans", dashboard.totalScans, ScanRunning)
+                DashboardMetric("Blocked", dashboard.policyViolationsBlocked, GradeD)
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "${dashboard.reposGradeA} grade A",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = GradeA,
+                )
+                Text(
+                    text = "${dashboard.reposGradeF} grade F",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = GradeF,
+                )
+                Text(
+                    text = "${dashboard.reposWithScanning} scanning",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DashboardMetric(label: String, value: Long, color: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(color.copy(alpha = 0.10f))
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = value.toString(),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = color,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = color.copy(alpha = 0.8f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun RepoScoreCard(score: ScoreResponse) {
+    val gradeColor = when (score.grade.uppercase()) {
+        "A" -> GradeA
+        "B" -> GradeB
+        "C" -> GradeC
+        "D" -> GradeD
+        else -> GradeF
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text(
+                        text = "Security Score",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = "${score.score}/100",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(gradeColor),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = score.grade.uppercase(),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ScorePill("C", score.criticalCount, Critical)
+                ScorePill("H", score.highCount, High)
+                ScorePill("M", score.mediumCount, Medium)
+                ScorePill("L", score.lowCount, Low)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScanConfigCard(config: ScanConfigResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Scan Configuration",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ConfigRow("Scanning enabled", config.scanEnabled)
+            ConfigRow("Scan on upload", config.scanOnUpload)
+            ConfigRow("Scan on proxy", config.scanOnProxy)
+            ConfigRow("Block on policy violation", config.blockOnPolicyViolation)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Severity threshold: ${config.severityThreshold.replaceFirstChar { it.uppercase() }}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConfigRow(label: String, enabled: Boolean) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodySmall)
+        Text(
+            text = if (enabled) "On" else "Off",
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.SemiBold,
+            color = if (enabled) ScanCompleted else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun RepoScanRow(scan: ScanResponse) {
+    val statusColor = when (scan.status.lowercase()) {
+        "completed", "complete" -> ScanCompleted
+        "running", "in_progress" -> ScanRunning
+        "failed", "error" -> ScanFailed
+        else -> ScanPending
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = scan.scanType.replaceFirstChar { it.uppercase() },
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(statusColor.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = scan.status.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = statusColor,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ScorePill("C", scan.criticalCount, Critical)
+                ScorePill("H", scan.highCount, High)
+                ScorePill("M", scan.mediumCount, Medium)
+                ScorePill("L", scan.lowCount, Low)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScorePill(label: String, count: Int, color: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = "$label: $count",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/RepoSecurityViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/RepoSecurityViewModel.kt
@@ -1,0 +1,113 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.DashboardResponse
+import com.artifactkeeper.client.models.ScanConfigResponse
+import com.artifactkeeper.client.models.ScanResponse
+import com.artifactkeeper.client.models.ScoreResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * State for a single repository's security view: its scan config, security
+ * score, and the scans run against it.
+ */
+data class RepoSecurityUiState(
+    val config: ScanConfigResponse? = null,
+    val score: ScoreResponse? = null,
+    val scans: List<ScanResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * State for the portfolio security dashboard summary.
+ */
+data class SecurityDashboardUiState(
+    val dashboard: DashboardResponse? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class RepoSecurityViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RepoSecurityUiState())
+    val uiState: StateFlow<RepoSecurityUiState> = _uiState.asStateFlow()
+
+    private val _dashboardState = MutableStateFlow(SecurityDashboardUiState())
+    val dashboardState: StateFlow<SecurityDashboardUiState> = _dashboardState.asStateFlow()
+
+    /**
+     * Load a repository's security config and score, plus its scans. The scan
+     * list is optional: a repo may have no scans yet, so a failure there does
+     * not fail the screen.
+     */
+    fun loadRepoSecurity(key: String, refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val security = apiClient.securityApi.getRepoSecurity(key).unwrap()
+
+                var scans: List<ScanResponse> = emptyList()
+                try {
+                    scans = apiClient.securityApi.listRepoScans(key).unwrap().items
+                } catch (_: Exception) {
+                    // No scans available for this repository.
+                }
+
+                _uiState.update {
+                    it.copy(
+                        config = security.config,
+                        score = security.score,
+                        scans = scans,
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load repository security",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Load the portfolio-level security dashboard summary.
+     */
+    fun loadDashboard() {
+        viewModelScope.launch {
+            _dashboardState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val dashboard = apiClient.securityApi.getDashboard().unwrap()
+                _dashboardState.update { it.copy(dashboard = dashboard, isLoading = false) }
+            } catch (e: Exception) {
+                _dashboardState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load security dashboard",
+                        isLoading = false,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/RepoSecurityViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/RepoSecurityViewModelTest.kt
@@ -1,0 +1,214 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.security.RepoSecurityUiState
+import com.artifactkeeper.android.ui.screens.security.RepoSecurityViewModel
+import com.artifactkeeper.android.ui.screens.security.SecurityDashboardUiState
+import com.artifactkeeper.client.apis.SecurityApi
+import com.artifactkeeper.client.models.DashboardResponse
+import com.artifactkeeper.client.models.RepoSecurityResponse
+import com.artifactkeeper.client.models.ScanConfigResponse
+import com.artifactkeeper.client.models.ScanListResponse
+import com.artifactkeeper.client.models.ScanResponse
+import com.artifactkeeper.client.models.ScoreResponse
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RepoSecurityViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockSecurityApi = mockk<SecurityApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { securityApi } returns mockSecurityApi
+    }
+
+    private val repoId = UUID.randomUUID()
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun score(grade: String = "B", critical: Int = 1) = ScoreResponse(
+        acknowledgedCount = 0,
+        calculatedAt = now,
+        criticalCount = critical,
+        grade = grade,
+        highCount = 2,
+        id = UUID.randomUUID(),
+        lowCount = 0,
+        mediumCount = 1,
+        repositoryId = repoId,
+        score = 80,
+        totalFindings = critical + 3,
+    )
+
+    private fun config() = ScanConfigResponse(
+        blockOnPolicyViolation = true,
+        createdAt = now,
+        id = UUID.randomUUID(),
+        repositoryId = repoId,
+        scanEnabled = true,
+        scanOnProxy = false,
+        scanOnUpload = true,
+        severityThreshold = "high",
+        updatedAt = now,
+    )
+
+    private fun scan() = ScanResponse(
+        artifactId = UUID.randomUUID(),
+        createdAt = now,
+        criticalCount = 1,
+        findingsCount = 3,
+        highCount = 2,
+        id = UUID.randomUUID(),
+        infoCount = 0,
+        isReused = false,
+        lowCount = 0,
+        mediumCount = 0,
+        repositoryId = repoId,
+        scanType = "vulnerability",
+        status = "completed",
+    )
+
+    private fun dashboard() = DashboardResponse(
+        criticalFindings = 5,
+        highFindings = 12,
+        policyViolationsBlocked = 2,
+        reposGradeA = 3,
+        reposGradeF = 1,
+        reposWithScanning = 7,
+        totalFindings = 40,
+        totalScans = 100,
+    )
+
+    // =========================================================================
+    // UI state
+    // =========================================================================
+
+    @Test
+    fun `initial repo state is empty`() {
+        val state = RepoSecurityUiState()
+        assertNull(state.config)
+        assertNull(state.score)
+        assertTrue(state.scans.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `initial dashboard state is empty`() {
+        val state = SecurityDashboardUiState()
+        assertNull(state.dashboard)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    // =========================================================================
+    // loadRepoSecurity
+    // =========================================================================
+
+    @Test
+    fun `loadRepoSecurity populates config score and scans`() = runTest {
+        coEvery { mockSecurityApi.getRepoSecurity("maven-local") } returns Response.success(
+            RepoSecurityResponse(config = config(), score = score()),
+        )
+        coEvery { mockSecurityApi.listRepoScans("maven-local") } returns Response.success(
+            ScanListResponse(items = listOf(scan(), scan()), total = 2),
+        )
+
+        val vm = RepoSecurityViewModel(mockApiClient)
+        vm.loadRepoSecurity("maven-local")
+
+        val state = vm.uiState.value
+        assertNotNull(state.config)
+        assertNotNull(state.score)
+        assertEquals(2, state.scans.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadRepoSecurity tolerates missing scans`() = runTest {
+        coEvery { mockSecurityApi.getRepoSecurity("maven-local") } returns Response.success(
+            RepoSecurityResponse(config = config(), score = score()),
+        )
+        coEvery { mockSecurityApi.listRepoScans("maven-local") } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "no scans"))
+
+        val vm = RepoSecurityViewModel(mockApiClient)
+        vm.loadRepoSecurity("maven-local")
+
+        val state = vm.uiState.value
+        assertNotNull(state.score)
+        assertTrue(state.scans.isEmpty())
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadRepoSecurity sets error when security fetch fails`() = runTest {
+        coEvery { mockSecurityApi.getRepoSecurity("maven-local") } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = RepoSecurityViewModel(mockApiClient)
+        vm.loadRepoSecurity("maven-local")
+
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    // =========================================================================
+    // loadDashboard
+    // =========================================================================
+
+    @Test
+    fun `loadDashboard populates the portfolio dashboard`() = runTest {
+        coEvery { mockSecurityApi.getDashboard() } returns Response.success(dashboard())
+
+        val vm = RepoSecurityViewModel(mockApiClient)
+        vm.loadDashboard()
+
+        val state = vm.dashboardState.value
+        assertNotNull(state.dashboard)
+        assertEquals(40L, state.dashboard?.totalFindings)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadDashboard sets error on failure`() = runTest {
+        coEvery { mockSecurityApi.getDashboard() } returns
+            Response.error(503, okhttp3.ResponseBody.create(null, "unavailable"))
+
+        val vm = RepoSecurityViewModel(mockApiClient)
+        vm.loadDashboard()
+
+        assertNotNull(vm.dashboardState.value.error)
+        assertFalse(vm.dashboardState.value.isLoading)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a per-repository security view and surfaces the portfolio dashboard summary.

- `RepoSecurityScreen` (reachable from a new "Security" card on the repository detail screen) shows: the portfolio security dashboard summary (critical/high/total findings, scans, grade A/F counts, repos with scanning, policy violations blocked), the repository's security score (grade badge + severity pills), its scan configuration (scanning enabled, scan on upload/proxy, block on policy violation, severity threshold), and the scans run against it.
- `RepoSecurityViewModel` is Hilt-injected with empty/loading/error states. The scan list is optional so a repo with no scans still renders.

No parity-matrix edits (maintained centrally).

Operations wired (previously missing):
- `get_dashboard` (GET /api/v1/security/dashboard)
- `get_repo_security` (GET /api/v1/repositories/{key}/security)
- `list_repo_scans` / get_repo_scans (GET /api/v1/repositories/{key}/security/scans)

(`get_all_scores` was already used by the security dashboard.)

Closes #96
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`RepoSecurityViewModelTest`: 7 tests, all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes