### PR TITLE
feat(security): Dependency-Track components, history, policies, analysis

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/DependencyTrackScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/DependencyTrackScreen.kt
@@ -24,7 +24,9 @@ import com.artifactkeeper.android.ui.theme.Critical
 import com.artifactkeeper.android.ui.theme.High
 import com.artifactkeeper.android.ui.theme.Low
 import com.artifactkeeper.android.ui.theme.Medium
+import com.artifactkeeper.client.models.DtComponentFull
 import com.artifactkeeper.client.models.DtFinding
+import com.artifactkeeper.client.models.DtPolicyFull
 import com.artifactkeeper.client.models.DtPolicyViolation
 import com.artifactkeeper.client.models.DtProject
 import com.artifactkeeper.client.models.DtProjectMetrics
@@ -42,8 +44,12 @@ fun DependencyTrackScreen(
     viewModel: DependencyTrackViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    val policiesState by viewModel.policiesState.collectAsState()
 
-    LaunchedEffect(Unit) { viewModel.loadProjects() }
+    LaunchedEffect(Unit) {
+        viewModel.loadProjects()
+        viewModel.loadPolicies()
+    }
 
     when {
         state.isLoading -> {
@@ -81,11 +87,61 @@ fun DependencyTrackScreen(
                 contentPadding = PaddingValues(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
+                if (policiesState.policies.isNotEmpty()) {
+                    item { DtPoliciesCard(policiesState.policies) }
+                }
+                item {
+                    Text(
+                        text = "Projects (${state.projects.size})",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
                 items(state.projects, key = { it.uuid }) { project ->
                     DtProjectCard(
                         project = project,
                         onClick = { onProjectClick(project.uuid, project.name) },
                     )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DtPoliciesCard(policies: List<DtPolicyFull>) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Policies (${policies.size})",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            policies.forEach { policy ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = policy.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(ViolationColor.copy(alpha = 0.15f))
+                            .padding(horizontal = 10.dp, vertical = 4.dp),
+                    ) {
+                        Text(
+                            text = policy.violationState.replaceFirstChar { it.uppercase() },
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = ViolationColor,
+                        )
+                    }
                 }
             }
         }
@@ -194,7 +250,7 @@ fun DtProjectDetailScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     state.metrics?.let { metrics ->
-                        item { DtMetricsCard(metrics) }
+                        item { DtMetricsCard(metrics, state.metricsHistory) }
                     }
 
                     if (state.violations.isNotEmpty()) {
@@ -228,7 +284,44 @@ fun DtProjectDetailScreen(
                         }
                     } else {
                         items(state.findings, key = { it.vulnerability.uuid }) { finding ->
-                            DtFindingCard(finding)
+                            DtFindingCard(
+                                finding = finding,
+                                isUpdating = state.isUpdating,
+                                onSuppress = {
+                                    viewModel.updateFindingAnalysis(
+                                        projectUuid = projectUuid,
+                                        componentUuid = finding.component.uuid,
+                                        vulnerabilityUuid = finding.vulnerability.uuid,
+                                        state = "NOT_AFFECTED",
+                                        suppressed = true,
+                                        justification = null,
+                                    )
+                                },
+                                onUnsuppress = {
+                                    viewModel.updateFindingAnalysis(
+                                        projectUuid = projectUuid,
+                                        componentUuid = finding.component.uuid,
+                                        vulnerabilityUuid = finding.vulnerability.uuid,
+                                        state = "EXPLOITABLE",
+                                        suppressed = false,
+                                        justification = null,
+                                    )
+                                },
+                            )
+                        }
+                    }
+
+                    if (state.components.isNotEmpty()) {
+                        item {
+                            Text(
+                                text = "Components (${state.components.size})",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                        items(state.components, key = { it.uuid }) { component ->
+                            DtComponentCard(component)
                         }
                     }
                 }
@@ -238,7 +331,7 @@ fun DtProjectDetailScreen(
 }
 
 @Composable
-private fun DtMetricsCard(metrics: DtProjectMetrics) {
+private fun DtMetricsCard(metrics: DtProjectMetrics, history: List<DtProjectMetrics> = emptyList()) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
@@ -270,6 +363,26 @@ private fun DtMetricsCard(metrics: DtProjectMetrics) {
                     text = "Audited $audited / $total findings",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // Findings trend over the recorded history window.
+            if (history.size >= 2) {
+                val first = history.first().findingsTotal ?: 0L
+                val last = history.last().findingsTotal ?: 0L
+                val delta = last - first
+                val trendColor = when {
+                    delta > 0 -> Critical
+                    delta < 0 -> Low
+                    else -> MaterialTheme.colorScheme.onSurfaceVariant
+                }
+                val sign = if (delta > 0) "+" else ""
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Trend over ${history.size} snapshots: $sign$delta findings",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium,
+                    color = trendColor,
                 )
             }
         }
@@ -318,9 +431,15 @@ private fun DtViolationCard(violation: DtPolicyViolation) {
 }
 
 @Composable
-private fun DtFindingCard(finding: DtFinding) {
+private fun DtFindingCard(
+    finding: DtFinding,
+    isUpdating: Boolean = false,
+    onSuppress: () -> Unit = {},
+    onUnsuppress: () -> Unit = {},
+) {
     val vuln = finding.vulnerability
     val sevColor = dtSeverityColor(vuln.severity)
+    val isSuppressed = finding.analysis?.isSuppressed == true
 
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -391,6 +510,55 @@ private fun DtFindingCard(finding: DtFinding) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 3,
                     overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
+                if (isSuppressed) {
+                    TextButton(onClick = onUnsuppress, enabled = !isUpdating) {
+                        Text("Reactivate")
+                    }
+                } else {
+                    TextButton(onClick = onSuppress, enabled = !isUpdating) {
+                        Text("Mark not affected")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DtComponentCard(component: DtComponentFull) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = buildString {
+                        component.group?.takeIf { it.isNotBlank() }?.let { append("$it:") }
+                        append(component.name)
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                component.version?.takeIf { it.isNotBlank() }?.let { ver ->
+                    Text(
+                        text = ver,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            component.resolvedLicense?.let { license ->
+                Text(
+                    text = license.licenseId ?: license.name,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/DependencyTrackViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/DependencyTrackViewModel.kt
@@ -4,10 +4,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.artifactkeeper.android.data.api.ApiClient
 import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.DtComponentFull
 import com.artifactkeeper.client.models.DtFinding
+import com.artifactkeeper.client.models.DtPolicyFull
 import com.artifactkeeper.client.models.DtPolicyViolation
 import com.artifactkeeper.client.models.DtProject
 import com.artifactkeeper.client.models.DtProjectMetrics
+import com.artifactkeeper.client.models.UpdateAnalysisBody
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -34,6 +37,18 @@ data class DtProjectDetailUiState(
     val metrics: DtProjectMetrics? = null,
     val findings: List<DtFinding> = emptyList(),
     val violations: List<DtPolicyViolation> = emptyList(),
+    val components: List<DtComponentFull> = emptyList(),
+    val metricsHistory: List<DtProjectMetrics> = emptyList(),
+    val isLoading: Boolean = false,
+    val isUpdating: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * State for the Dependency-Track policy list.
+ */
+data class DtPoliciesUiState(
+    val policies: List<DtPolicyFull> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
 )
@@ -48,6 +63,9 @@ class DependencyTrackViewModel @Inject constructor(
 
     private val _projectDetailState = MutableStateFlow(DtProjectDetailUiState())
     val projectDetailState: StateFlow<DtProjectDetailUiState> = _projectDetailState.asStateFlow()
+
+    private val _policiesState = MutableStateFlow(DtPoliciesUiState())
+    val policiesState: StateFlow<DtPoliciesUiState> = _policiesState.asStateFlow()
 
     fun loadProjects(refresh: Boolean = false) {
         viewModelScope.launch {
@@ -96,11 +114,27 @@ class DependencyTrackViewModel @Inject constructor(
                     // No policy violations available for this project.
                 }
 
+                var components: List<DtComponentFull> = emptyList()
+                try {
+                    components = apiClient.securityApi.getProjectComponents(projectUuid).unwrap()
+                } catch (_: Exception) {
+                    // Component inventory not available for this project.
+                }
+
+                var metricsHistory: List<DtProjectMetrics> = emptyList()
+                try {
+                    metricsHistory = apiClient.securityApi.getProjectMetricsHistory(projectUuid).unwrap()
+                } catch (_: Exception) {
+                    // No metrics history available for this project.
+                }
+
                 _projectDetailState.update {
                     it.copy(
                         metrics = metrics,
                         findings = findings,
                         violations = violations,
+                        components = components,
+                        metricsHistory = metricsHistory,
                         isLoading = false,
                     )
                 }
@@ -110,6 +144,55 @@ class DependencyTrackViewModel @Inject constructor(
                         error = e.message ?: "Failed to load project detail",
                         isLoading = false,
                     )
+                }
+            }
+        }
+    }
+
+    fun loadPolicies() {
+        viewModelScope.launch {
+            _policiesState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val policies = apiClient.securityApi.listDependencyTrackPolicies().unwrap()
+                _policiesState.update { it.copy(policies = policies, isLoading = false) }
+            } catch (e: Exception) {
+                _policiesState.update {
+                    it.copy(error = e.message ?: "Failed to load policies", isLoading = false)
+                }
+            }
+        }
+    }
+
+    /**
+     * Update the audit analysis for a finding (e.g. mark not affected and
+     * suppress), then reload the project detail to reflect the change.
+     */
+    fun updateFindingAnalysis(
+        projectUuid: String,
+        componentUuid: String,
+        vulnerabilityUuid: String,
+        state: String,
+        suppressed: Boolean,
+        justification: String?,
+    ) {
+        viewModelScope.launch {
+            _projectDetailState.update { it.copy(isUpdating = true, error = null) }
+            try {
+                apiClient.securityApi.updateAnalysis(
+                    UpdateAnalysisBody(
+                        componentUuid = componentUuid,
+                        projectUuid = projectUuid,
+                        state = state,
+                        vulnerabilityUuid = vulnerabilityUuid,
+                        justification = justification,
+                        suppressed = suppressed,
+                    ),
+                ).unwrap()
+                _projectDetailState.update { it.copy(isUpdating = false) }
+                loadProjectDetail(projectUuid)
+            } catch (e: Exception) {
+                _projectDetailState.update {
+                    it.copy(error = e.message ?: "Failed to update analysis", isUpdating = false)
                 }
             }
         }

--- a/app/src/test/java/com/artifactkeeper/android/DependencyTrackExtrasViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/DependencyTrackExtrasViewModelTest.kt
@@ -1,0 +1,202 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.security.DependencyTrackViewModel
+import com.artifactkeeper.android.ui.screens.security.DtPoliciesUiState
+import com.artifactkeeper.client.apis.SecurityApi
+import com.artifactkeeper.client.models.DtComponent
+import com.artifactkeeper.client.models.DtComponentFull
+import com.artifactkeeper.client.models.DtFinding
+import com.artifactkeeper.client.models.DtAnalysisResponse
+import com.artifactkeeper.client.models.DtPolicy
+import com.artifactkeeper.client.models.DtPolicyConditionFull
+import com.artifactkeeper.client.models.DtPolicyFull
+import com.artifactkeeper.client.models.DtProjectMetrics
+import com.artifactkeeper.client.models.DtVulnerability
+import com.artifactkeeper.client.models.UpdateAnalysisBody
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DependencyTrackExtrasViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockSecurityApi = mockk<SecurityApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { securityApi } returns mockSecurityApi
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun metrics() = DtProjectMetrics(critical = 1, high = 2, findingsTotal = 5, findingsAudited = 2)
+
+    private fun finding(severity: String) = DtFinding(
+        component = DtComponent(name = "libfoo", uuid = "c-1", version = "1.0.0"),
+        vulnerability = DtVulnerability(severity = severity, source = "NVD", uuid = "v-1", vulnId = "CVE-1"),
+    )
+
+    private fun component(name: String) = DtComponentFull(name = name, uuid = "cf-$name", version = "1.0.0")
+
+    private fun policy(name: String) = DtPolicyFull(
+        name = name,
+        policyConditions = emptyList<DtPolicyConditionFull>(),
+        projects = emptyList(),
+        tags = emptyList<Any>(),
+        uuid = "pol-$name",
+        violationState = "FAIL",
+    )
+
+    private fun analysisResponse() = DtAnalysisResponse(
+        analysisState = "NOT_AFFECTED",
+        isSuppressed = true,
+    )
+
+    // detail now includes components + metrics history (both optional)
+
+    @Test
+    fun `loadProjectDetail also loads components and metrics history`() = runTest {
+        coEvery { mockSecurityApi.getProjectMetrics("p-1") } returns Response.success(metrics())
+        coEvery { mockSecurityApi.getProjectFindings("p-1") } returns Response.success(listOf(finding("HIGH")))
+        coEvery { mockSecurityApi.getProjectViolations("p-1") } returns Response.success(emptyList())
+        coEvery { mockSecurityApi.getProjectComponents("p-1") } returns
+            Response.success(listOf(component("a"), component("b")))
+        coEvery { mockSecurityApi.getProjectMetricsHistory("p-1", any()) } returns
+            Response.success(listOf(metrics(), metrics(), metrics()))
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadProjectDetail("p-1")
+
+        val state = vm.projectDetailState.value
+        assertEquals(2, state.components.size)
+        assertEquals(3, state.metricsHistory.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadProjectDetail tolerates missing components and history`() = runTest {
+        coEvery { mockSecurityApi.getProjectMetrics("p-1") } returns Response.success(metrics())
+        coEvery { mockSecurityApi.getProjectFindings("p-1") } returns Response.success(listOf(finding("HIGH")))
+        coEvery { mockSecurityApi.getProjectViolations("p-1") } returns Response.success(emptyList())
+        coEvery { mockSecurityApi.getProjectComponents("p-1") } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "no components"))
+        coEvery { mockSecurityApi.getProjectMetricsHistory("p-1", any()) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "no history"))
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadProjectDetail("p-1")
+
+        val state = vm.projectDetailState.value
+        assertNotNull(state.metrics)
+        assertTrue(state.components.isEmpty())
+        assertTrue(state.metricsHistory.isEmpty())
+        assertNull(state.error)
+    }
+
+    // policies
+
+    @Test
+    fun `initial policies state is empty`() {
+        val state = DtPoliciesUiState()
+        assertTrue(state.policies.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadPolicies populates policy list`() = runTest {
+        coEvery { mockSecurityApi.listDependencyTrackPolicies() } returns
+            Response.success(listOf(policy("License"), policy("Severity")))
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadPolicies()
+
+        assertEquals(2, vm.policiesState.value.policies.size)
+        assertNull(vm.policiesState.value.error)
+    }
+
+    @Test
+    fun `loadPolicies sets error on failure`() = runTest {
+        coEvery { mockSecurityApi.listDependencyTrackPolicies() } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.loadPolicies()
+
+        assertNotNull(vm.policiesState.value.error)
+    }
+
+    // update analysis
+
+    @Test
+    fun `updateFindingAnalysis sends request and reloads detail`() = runTest {
+        coEvery { mockSecurityApi.updateAnalysis(any()) } returns Response.success(analysisResponse())
+        // reload after update
+        coEvery { mockSecurityApi.getProjectMetrics("p-1") } returns Response.success(metrics())
+        coEvery { mockSecurityApi.getProjectFindings("p-1") } returns Response.success(listOf(finding("HIGH")))
+        coEvery { mockSecurityApi.getProjectViolations("p-1") } returns Response.success(emptyList())
+        coEvery { mockSecurityApi.getProjectComponents("p-1") } returns Response.success(emptyList())
+        coEvery { mockSecurityApi.getProjectMetricsHistory("p-1", any()) } returns Response.success(emptyList())
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.updateFindingAnalysis(
+            projectUuid = "p-1",
+            componentUuid = "c-1",
+            vulnerabilityUuid = "v-1",
+            state = "NOT_AFFECTED",
+            suppressed = true,
+            justification = "code not reachable",
+        )
+
+        coVerify {
+            mockSecurityApi.updateAnalysis(
+                UpdateAnalysisBody(
+                    componentUuid = "c-1",
+                    projectUuid = "p-1",
+                    state = "NOT_AFFECTED",
+                    vulnerabilityUuid = "v-1",
+                    justification = "code not reachable",
+                    suppressed = true,
+                ),
+            )
+        }
+        assertFalse(vm.projectDetailState.value.isUpdating)
+    }
+
+    @Test
+    fun `updateFindingAnalysis sets error on failure`() = runTest {
+        coEvery { mockSecurityApi.updateAnalysis(any()) } returns
+            Response.error(400, okhttp3.ResponseBody.create(null, "bad"))
+
+        val vm = DependencyTrackViewModel(mockApiClient)
+        vm.updateFindingAnalysis("p-1", "c-1", "v-1", "EXPLOITABLE", false, null)
+
+        assertNotNull(vm.projectDetailState.value.error)
+        assertFalse(vm.projectDetailState.value.isUpdating)
+    }
+}


### PR DESCRIPTION
## Summary
Extends the Dependency-Track surface (added in #91) with the remaining project detail data and finding triage.

- Project detail gains a Components section (component inventory with group/name/version and resolved license) and a findings trend summary computed over the recorded metrics history (delta in total findings across snapshots, colored by direction).
- Findings can be marked not affected (suppressed) or reactivated from the project detail via the analysis update action.
- The projects screen gains a Policies summary card listing configured DT policies and their violation state.
- Components and metrics history are treated as optional so a project without them still renders.

Rebased onto current main (after #97 landed). No nav-host changes; no parity-matrix edits (maintained centrally).

Operations wired (previously missing):
- `get_project_components` (GET /api/v1/dependency-track/projects/{project_uuid}/components)
- `get_project_metrics_history` (GET /api/v1/dependency-track/projects/{project_uuid}/metrics/history)
- `list_dependency_track_policies` (GET /api/v1/dependency-track/policies)
- `update_analysis` (PUT /api/v1/dependency-track/analysis)

Closes #98
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`DependencyTrackExtrasViewModelTest`: 7 tests, all passing; existing `DependencyTrackViewModelTest` 9/9 still green. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes