### PR TITLE
feat(security): signing keys management

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -16,6 +16,7 @@ import com.artifactkeeper.client.apis.PromotionApi
 import com.artifactkeeper.client.apis.RepositoriesApi
 import com.artifactkeeper.client.apis.SbomApi
 import com.artifactkeeper.client.apis.SecurityApi
+import com.artifactkeeper.client.apis.SigningApi
 import com.artifactkeeper.client.apis.SsoApi
 import com.artifactkeeper.client.apis.UsersApi
 import com.artifactkeeper.client.apis.WebhooksApi
@@ -64,6 +65,7 @@ object ApiClient {
     lateinit var monitoringApi: MonitoringApi private set
     lateinit var healthApi: HealthApi private set
     lateinit var sbomApi: SbomApi private set
+    lateinit var signingApi: SigningApi private set
     lateinit var ssoApi: SsoApi private set
     lateinit var promotionApi: PromotionApi private set
     lateinit var stagingApi: StagingApi private set
@@ -128,6 +130,7 @@ object ApiClient {
         monitoringApi = client.createService(MonitoringApi::class.java)
         healthApi = client.createService(HealthApi::class.java)
         sbomApi = client.createService(SbomApi::class.java)
+        signingApi = client.createService(SigningApi::class.java)
         ssoApi = client.createService(SsoApi::class.java)
         promotionApi = client.createService(PromotionApi::class.java)
         stagingApi = client.createService(StagingApi::class.java)

--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -68,6 +68,7 @@ import com.artifactkeeper.android.ui.screens.security.PoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.RepoSecurityScreen
 import com.artifactkeeper.android.ui.screens.security.ScanDetailScreen
 import com.artifactkeeper.android.ui.screens.security.ScansScreen
+import com.artifactkeeper.android.ui.screens.security.SigningKeysScreen
 import com.artifactkeeper.android.ui.screens.security.SecurityScreen
 import com.artifactkeeper.android.ui.screens.settings.SettingsScreen
 import com.artifactkeeper.android.ui.screens.auth.ChangePasswordScreen
@@ -596,7 +597,7 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SecuritySection(isCompact: Boolean, accountActions: @Composable () -> Unit) {
-    val subTabs = listOf("Dashboard", "Scans", "Dep-Track", "Policies", "Licenses")
+    val subTabs = listOf("Dashboard", "Scans", "Dep-Track", "Policies", "Licenses", "Signing")
     var selectedTab by remember { mutableIntStateOf(0) }
     var selectedScanId by remember { mutableStateOf<String?>(null) }
     var selectedDtProject by remember { mutableStateOf<Pair<String, String>?>(null) }
@@ -639,6 +640,7 @@ private fun SecuritySection(isCompact: Boolean, accountActions: @Composable () -
                 )
                 3 -> PoliciesScreen()
                 4 -> LicensePoliciesScreen()
+                5 -> SigningKeysScreen()
             }
         }
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SigningKeysScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SigningKeysScreen.kt
@@ -1,0 +1,307 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.SigningKeyPublic
+import java.util.UUID
+
+private val ActiveColor = Color(0xFF52C41A)
+private val RevokedColor = Color(0xFFF5222D)
+
+/** Key algorithms offered in the create-key dialog. */
+private val KeyAlgorithms = listOf("ed25519", "rsa", "ecdsa")
+
+/**
+ * Signing keys management: lists keys, creates new keys, and rotates, revokes,
+ * or deletes existing ones.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SigningKeysScreen(
+    viewModel: SigningViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showCreateDialog by remember { mutableStateOf(false) }
+    var keyToRevoke by remember { mutableStateOf<SigningKeyPublic?>(null) }
+    var keyToDelete by remember { mutableStateOf<SigningKeyPublic?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) { viewModel.loadKeys() }
+
+    LaunchedEffect(state.message, state.error) {
+        val text = state.message ?: state.error
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearMessages()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Create signing key")
+            }
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.error != null && state.keys.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = state.error ?: "Unknown error",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { viewModel.loadKeys(refresh = true) }) {
+                                Text("Retry")
+                            }
+                        }
+                    }
+                }
+                state.keys.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "No signing keys. Use + to create one.",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(state.keys, key = { it.id }) { key ->
+                            SigningKeyCard(
+                                key = key,
+                                isMutating = state.isMutating,
+                                onRotate = { viewModel.rotateKey(key.id) },
+                                onRevoke = { keyToRevoke = key },
+                                onDelete = { keyToDelete = key },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreateDialog) {
+        CreateKeyDialog(
+            isMutating = state.isMutating,
+            onDismiss = { showCreateDialog = false },
+            onConfirm = { name, algorithm ->
+                viewModel.createKey(name = name, algorithm = algorithm, keyType = null)
+                showCreateDialog = false
+            },
+        )
+    }
+
+    keyToRevoke?.let { key ->
+        ConfirmDialog(
+            title = "Revoke key",
+            message = "Revoke \"${key.name}\"? Signatures made with it will no longer validate.",
+            confirmLabel = "Revoke",
+            onConfirm = {
+                viewModel.revokeKey(key.id)
+                keyToRevoke = null
+            },
+            onDismiss = { keyToRevoke = null },
+        )
+    }
+
+    keyToDelete?.let { key ->
+        ConfirmDialog(
+            title = "Delete key",
+            message = "Permanently delete \"${key.name}\"? This cannot be undone.",
+            confirmLabel = "Delete",
+            onConfirm = {
+                viewModel.deleteKey(key.id)
+                keyToDelete = null
+            },
+            onDismiss = { keyToDelete = null },
+        )
+    }
+}
+
+@Composable
+private fun SigningKeyCard(
+    key: SigningKeyPublic,
+    isMutating: Boolean,
+    onRotate: () -> Unit,
+    onRevoke: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Key,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Text(
+                        text = key.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                StatusBadge(active = key.isActive)
+            }
+
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${key.keyType.uppercase()} - ${key.algorithm}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            key.fingerprint?.takeIf { it.isNotBlank() }?.let { fp ->
+                Text(
+                    text = fp,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                TextButton(onClick = onRotate, enabled = !isMutating) { Text("Rotate") }
+                if (key.isActive) {
+                    TextButton(onClick = onRevoke, enabled = !isMutating) { Text("Revoke") }
+                }
+                TextButton(onClick = onDelete, enabled = !isMutating) { Text("Delete") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusBadge(active: Boolean) {
+    val color = if (active) ActiveColor else RevokedColor
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = if (active) "Active" else "Revoked",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CreateKeyDialog(
+    isMutating: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (name: String, algorithm: String) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var algorithm by remember { mutableStateOf(KeyAlgorithms.first()) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Create signing key") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text("Algorithm", style = MaterialTheme.typography.labelMedium)
+                KeyAlgorithms.forEach { algo ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = algorithm == algo,
+                            onClick = { algorithm = algo },
+                        )
+                        Text(algo)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name.trim(), algorithm) },
+                enabled = !isMutating && name.isNotBlank(),
+            ) {
+                Text("Create")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}
+
+@Composable
+private fun ConfirmDialog(
+    title: String,
+    message: String,
+    confirmLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(message) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text(confirmLabel) }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SigningViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SigningViewModel.kt
@@ -1,0 +1,113 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.CreateKeyPayload
+import com.artifactkeeper.client.models.SigningKeyPublic
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for the signing keys screen.
+ */
+data class SigningUiState(
+    val keys: List<SigningKeyPublic> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+)
+
+@HiltViewModel
+class SigningViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SigningUiState())
+    val uiState: StateFlow<SigningUiState> = _uiState.asStateFlow()
+
+    fun loadKeys(refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val keys = apiClient.signingApi.listKeys(null).unwrap().propertyKeys
+                    .sortedWith(compareByDescending<SigningKeyPublic> { it.isActive }.thenBy { it.name.lowercase() })
+                _uiState.update {
+                    it.copy(keys = keys, isLoading = false, isRefreshing = false)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load signing keys",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun createKey(name: String, algorithm: String?, keyType: String?) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.signingApi.createKey(
+                    CreateKeyPayload(
+                        name = name,
+                        algorithm = algorithm,
+                        keyType = keyType,
+                    ),
+                ).unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Key created") }
+                loadKeys()
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to create key", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun revokeKey(keyId: UUID) = mutate("Key revoked", "Failed to revoke key") {
+        apiClient.signingApi.revokeKey(keyId).unwrap()
+    }
+
+    fun rotateKey(keyId: UUID) = mutate("Key rotated", "Failed to rotate key") {
+        apiClient.signingApi.rotateKey(keyId).unwrap()
+    }
+
+    fun deleteKey(keyId: UUID) = mutate("Key deleted", "Failed to delete key") {
+        apiClient.signingApi.deleteKey(keyId).unwrap()
+    }
+
+    fun clearMessages() {
+        _uiState.update { it.copy(error = null, message = null) }
+    }
+
+    private fun mutate(successMessage: String, failureMessage: String, block: suspend () -> Unit) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                block()
+                _uiState.update { it.copy(isMutating = false, message = successMessage) }
+                loadKeys()
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: failureMessage, isMutating = false)
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/SigningViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/SigningViewModelTest.kt
@@ -1,0 +1,206 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.security.SigningUiState
+import com.artifactkeeper.android.ui.screens.security.SigningViewModel
+import com.artifactkeeper.client.apis.SigningApi
+import com.artifactkeeper.client.models.CreateKeyPayload
+import com.artifactkeeper.client.models.KeyListResponse
+import com.artifactkeeper.client.models.SigningKeyPublic
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SigningViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockSigningApi = mockk<SigningApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { signingApi } returns mockSigningApi
+    }
+
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun key(name: String, active: Boolean = true, id: UUID = UUID.randomUUID()) = SigningKeyPublic(
+        algorithm = "ed25519",
+        createdAt = now,
+        id = id,
+        isActive = active,
+        keyType = "gpg",
+        name = name,
+        publicKeyPem = "-----BEGIN PUBLIC KEY-----\nABC\n-----END PUBLIC KEY-----",
+    )
+
+    // =========================================================================
+    // UI state
+    // =========================================================================
+
+    @Test
+    fun `initial state is empty`() {
+        val state = SigningUiState()
+        assertTrue(state.keys.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertNull(state.message)
+    }
+
+    // =========================================================================
+    // loadKeys
+    // =========================================================================
+
+    @Test
+    fun `loadKeys populates keys with active first`() = runTest {
+        coEvery { mockSigningApi.listKeys(null) } returns Response.success(
+            KeyListResponse(
+                propertyKeys = listOf(key("revoked", active = false), key("live", active = true)),
+                total = 2,
+            ),
+        )
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.loadKeys()
+
+        val state = vm.uiState.value
+        assertEquals(2, state.keys.size)
+        // active sorts before inactive
+        assertTrue(state.keys.first().isActive)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadKeys sets error on failure`() = runTest {
+        coEvery { mockSigningApi.listKeys(null) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.loadKeys()
+
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    // =========================================================================
+    // createKey
+    // =========================================================================
+
+    @Test
+    fun `createKey posts payload and reloads`() = runTest {
+        coEvery { mockSigningApi.createKey(any()) } returns Response.success(key("new"))
+        coEvery { mockSigningApi.listKeys(null) } returns Response.success(
+            KeyListResponse(propertyKeys = listOf(key("new")), total = 1),
+        )
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.createKey(name = "new", algorithm = "ed25519", keyType = "gpg")
+
+        coVerify {
+            mockSigningApi.createKey(
+                CreateKeyPayload(name = "new", algorithm = "ed25519", keyType = "gpg"),
+            )
+        }
+        assertEquals(1, vm.uiState.value.keys.size)
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `createKey sets error on failure`() = runTest {
+        coEvery { mockSigningApi.createKey(any()) } returns
+            Response.error(400, okhttp3.ResponseBody.create(null, "bad"))
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.createKey(name = "x", algorithm = null, keyType = null)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+
+    // =========================================================================
+    // revoke / rotate / delete
+    // =========================================================================
+
+    @Test
+    fun `revokeKey calls api and reloads`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockSigningApi.revokeKey(id) } returns Response.success(Unit)
+        coEvery { mockSigningApi.listKeys(null) } returns Response.success(
+            KeyListResponse(propertyKeys = emptyList(), total = 0),
+        )
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.revokeKey(id)
+
+        coVerify { mockSigningApi.revokeKey(id) }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `rotateKey calls api and reloads`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockSigningApi.rotateKey(id) } returns Response.success(key("rotated"))
+        coEvery { mockSigningApi.listKeys(null) } returns Response.success(
+            KeyListResponse(propertyKeys = listOf(key("rotated")), total = 1),
+        )
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.rotateKey(id)
+
+        coVerify { mockSigningApi.rotateKey(id) }
+        assertEquals(1, vm.uiState.value.keys.size)
+    }
+
+    @Test
+    fun `deleteKey calls api and reloads`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockSigningApi.deleteKey(id) } returns Response.success(Unit)
+        coEvery { mockSigningApi.listKeys(null) } returns Response.success(
+            KeyListResponse(propertyKeys = emptyList(), total = 0),
+        )
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.deleteKey(id)
+
+        coVerify { mockSigningApi.deleteKey(id) }
+        assertTrue(vm.uiState.value.keys.isEmpty())
+    }
+
+    @Test
+    fun `revokeKey sets error on failure`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockSigningApi.revokeKey(id) } returns
+            Response.error(409, okhttp3.ResponseBody.create(null, "conflict"))
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.revokeKey(id)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+}


### PR DESCRIPTION
## Summary
Adds signing key management to the Security section.

- New "Signing" sub-tab. `SigningKeysScreen` lists signing keys (active first) with key type, algorithm, and fingerprint.
- Create a key (name + algorithm radio: ed25519 / rsa / ecdsa) via a dialog. Rotate, revoke (active keys only), and delete keys, each with a confirmation dialog. Results surface via a snackbar.
- `SigningViewModel` is Hilt-injected with loading/error/message states and an isMutating guard on actions.
- Adds `SigningApi` to the app's `ApiClient`.

Rebased onto current main (after #99 landed). Nav host change is additive (one new sub-tab, index 5); no parity-matrix edits (maintained centrally).

Operations wired (previously missing):
- `list_keys` (GET /api/v1/signing/keys)
- `create_key` (POST /api/v1/signing/keys)
- `revoke_key` (POST /api/v1/signing/keys/{key_id}/revoke)
- `rotate_key` (POST /api/v1/signing/keys/{key_id}/rotate)
- `delete_key` (DELETE /api/v1/signing/keys/{key_id})

Deferred follow-up (not in this PR): `get_key`, `get_public_key`, `get_repo_public_key`, `get_repo_signing_config`, `update_repo_signing_config`.

Closes #100
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`SigningViewModelTest`: 9 tests, all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes