### PR TITLE
feat(search): dedicated 1.2.1 search endpoints

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -16,6 +16,7 @@ import com.artifactkeeper.client.apis.PromotionApi
 import com.artifactkeeper.client.apis.QualityApi
 import com.artifactkeeper.client.apis.RepositoriesApi
 import com.artifactkeeper.client.apis.SbomApi
+import com.artifactkeeper.client.apis.SearchApi
 import com.artifactkeeper.client.apis.SecurityApi
 import com.artifactkeeper.client.apis.SigningApi
 import com.artifactkeeper.client.apis.SsoApi
@@ -67,6 +68,7 @@ object ApiClient {
     lateinit var healthApi: HealthApi private set
     lateinit var sbomApi: SbomApi private set
     lateinit var signingApi: SigningApi private set
+    lateinit var searchApi: SearchApi private set
     lateinit var ssoApi: SsoApi private set
     lateinit var promotionApi: PromotionApi private set
     lateinit var qualityApi: QualityApi private set
@@ -133,6 +135,7 @@ object ApiClient {
         healthApi = client.createService(HealthApi::class.java)
         sbomApi = client.createService(SbomApi::class.java)
         signingApi = client.createService(SigningApi::class.java)
+        searchApi = client.createService(SearchApi::class.java)
         ssoApi = client.createService(SsoApi::class.java)
         promotionApi = client.createService(PromotionApi::class.java)
         qualityApi = client.createService(QualityApi::class.java)

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/search/SearchScreen.kt
@@ -1,275 +1,254 @@
 package com.artifactkeeper.android.ui.screens.search
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Inventory2
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.artifactkeeper.android.ui.components.ItemTitleWithChip
-import com.artifactkeeper.android.data.api.ApiClient
-import com.artifactkeeper.android.data.api.unwrap
-import com.artifactkeeper.android.data.models.PackageItem
-import com.artifactkeeper.android.data.models.Repository
 import com.artifactkeeper.android.ui.util.formatBytes
-import kotlinx.coroutines.async
+import com.artifactkeeper.client.models.ChecksumArtifact
+import com.artifactkeeper.client.models.SearchResultItem
 import kotlinx.coroutines.delay
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-fun SearchScreen() {
-    var searchQuery by remember { mutableStateOf("") }
-    var repoResults by remember { mutableStateOf<List<Repository>>(emptyList()) }
-    var artifactResults by remember { mutableStateOf<List<PackageItem>>(emptyList()) }
-    var isSearching by remember { mutableStateOf(false) }
-    var hasSearched by remember { mutableStateOf(false) }
-    var errorMessage by remember { mutableStateOf<String?>(null) }
+fun SearchScreen(
+    viewModel: SearchViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var query by remember { mutableStateOf("") }
 
-    // Debounced search
-    LaunchedEffect(searchQuery) {
-        if (searchQuery.isBlank()) {
-            repoResults = emptyList()
-            artifactResults = emptyList()
-            hasSearched = false
+    LaunchedEffect(Unit) { viewModel.loadInitial() }
+
+    // Debounce text search and suggestions; checksum search is explicit.
+    LaunchedEffect(query, state.mode) {
+        if (state.mode != SearchMode.TEXT) return@LaunchedEffect
+        if (query.isBlank()) {
+            viewModel.clear()
             return@LaunchedEffect
         }
+        viewModel.loadSuggestions(query)
         delay(300)
-        isSearching = true
-        errorMessage = null
-        try {
-            val reposDeferred = async {
-                try {
-                    ApiClient.reposApi.listRepositories(q = searchQuery, perPage = 20).unwrap().items
-                } catch (_: Exception) {
-                    emptyList<Repository>()
-                }
-            }
-            val artifactsDeferred = async {
-                try {
-                    ApiClient.packagesApi.listPackages(search = searchQuery, perPage = 20).unwrap().items
-                } catch (_: Exception) {
-                    emptyList<PackageItem>()
-                }
-            }
-            repoResults = reposDeferred.await()
-            artifactResults = artifactsDeferred.await()
-            hasSearched = true
-        } catch (e: Exception) {
-            errorMessage = e.message ?: "Search failed"
-            hasSearched = true
-        } finally {
-            isSearching = false
-        }
+        viewModel.quickSearch(query)
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        OutlinedTextField(
-            value = searchQuery,
-            onValueChange = { searchQuery = it },
+        SingleChoiceSegmentedButtonRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp),
-            placeholder = { Text("Search repositories & artifacts...") },
+        ) {
+            SegmentedButton(
+                selected = state.mode == SearchMode.TEXT,
+                onClick = {
+                    viewModel.setMode(SearchMode.TEXT)
+                    query = ""
+                },
+                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+            ) { Text("Text") }
+            SegmentedButton(
+                selected = state.mode == SearchMode.CHECKSUM,
+                onClick = {
+                    viewModel.setMode(SearchMode.CHECKSUM)
+                    query = ""
+                },
+                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+            ) { Text("Checksum") }
+        }
+
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            placeholder = {
+                Text(
+                    if (state.mode == SearchMode.TEXT) "Search artifacts and repositories"
+                    else "Paste a checksum (SHA-256)",
+                )
+            },
             leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Search") },
             singleLine = true,
         )
 
-        when {
-            isSearching -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator()
-                }
+        if (state.mode == SearchMode.CHECKSUM) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                FilterChip(
+                    selected = false,
+                    onClick = { viewModel.checksumSearch(query) },
+                    label = { Text("Search by checksum") },
+                )
             }
-            errorMessage != null -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text(
-                            text = errorMessage ?: "Unknown error",
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodyLarge,
-                        )
-                    }
-                }
-            }
-            !hasSearched -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Icon(
-                            Icons.Default.Search,
-                            contentDescription = null,
-                            modifier = Modifier.size(64.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "Search",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Text(
-                            text = "Find repositories and artifacts by name, key, or format",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                        )
-                    }
-                }
-            }
-            repoResults.isEmpty() && artifactResults.isEmpty() -> {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = "No results found for \"$searchQuery\"",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        } else if (state.suggestions.isNotEmpty()) {
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                state.suggestions.forEach { suggestion ->
+                    SuggestionChip(
+                        onClick = { query = suggestion },
+                        label = { Text(suggestion) },
                     )
                 }
             }
-            else -> {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    if (repoResults.isNotEmpty()) {
-                        item(key = "repo-header") {
-                            Text(
-                                text = "Repositories",
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.primary,
-                            )
-                        }
-                        items(repoResults, key = { "repo-${it.id}" }) { repo ->
-                            RepoSearchResultCard(repo)
-                        }
-                    }
-                    if (artifactResults.isNotEmpty()) {
-                        item(key = "artifact-header") {
-                            Text(
-                                text = "Artifacts",
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = if (repoResults.isNotEmpty()) Modifier.padding(top = 8.dp) else Modifier,
-                            )
-                        }
-                        items(artifactResults, key = { "artifact-${it.id}" }) { pkg ->
-                            ArtifactSearchResultCard(pkg)
-                        }
-                    }
-                }
+        }
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            when {
+                state.isSearching -> CenteredProgress()
+                state.error != null -> CenteredMessage(state.error!!, isError = true)
+                state.mode == SearchMode.CHECKSUM -> ChecksumContent(state.checksumResults, state.hasSearched)
+                !state.hasSearched -> InitialContent(state.recent, state.trending)
+                state.results.isEmpty() -> CenteredMessage("No results for \"$query\"")
+                else -> ResultList(state.results)
             }
         }
     }
 }
 
 @Composable
-private fun RepoSearchResultCard(repo: Repository) {
+private fun InitialContent(
+    recent: List<SearchResultItem>,
+    trending: List<SearchResultItem>,
+) {
+    if (recent.isEmpty() && trending.isEmpty()) {
+        CenteredMessage("Search artifacts and repositories by name, format, or checksum")
+        return
+    }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        if (trending.isNotEmpty()) {
+            item(key = "trending-header") { SectionHeader("Trending", icon = true) }
+            items(trending, key = { "trending-${it.id}" }) { ResultRow(it) }
+        }
+        if (recent.isNotEmpty()) {
+            item(key = "recent-header") { SectionHeader("Recent") }
+            items(recent, key = { "recent-${it.id}" }) { ResultRow(it) }
+        }
+    }
+}
+
+@Composable
+private fun ResultList(results: List<SearchResultItem>) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items(results, key = { it.id }) { ResultRow(it) }
+    }
+}
+
+@Composable
+private fun ChecksumContent(results: List<ChecksumArtifact>, hasSearched: Boolean) {
+    when {
+        !hasSearched -> CenteredMessage("Paste a checksum and tap Search by checksum")
+        results.isEmpty() -> CenteredMessage("No artifacts match that checksum")
+        else -> LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            items(results, key = { it.id }) { ChecksumRow(it) }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String, icon: Boolean = false) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (icon) {
+            Icon(
+                Icons.Default.TrendingUp,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+@Composable
+private fun ResultRow(item: SearchResultItem) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
-            ItemTitleWithChip(title = repo.name, chipLabel = repo.format.uppercase())
-
+            ItemTitleWithChip(title = item.name, chipLabel = (item.format ?: item.type).uppercase())
             Spacer(modifier = Modifier.height(4.dp))
-
             Text(
-                text = repo.key,
+                text = item.repositoryKey,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-
-            repo.description?.let { desc ->
-                if (desc.isNotBlank()) {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = desc,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        Icons.Default.Inventory2,
-                        contentDescription = "Storage",
-                        modifier = Modifier.size(16.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = formatBytes(repo.storageUsedBytes),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+            item.version?.let {
                 Text(
-                    text = repo.repoType,
+                    text = "v$it",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-        }
-    }
-}
-
-@Composable
-private fun ArtifactSearchResultCard(pkg: PackageItem) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            ItemTitleWithChip(title = pkg.name, chipLabel = pkg.format.uppercase())
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            Text(
-                text = pkg.repositoryKey,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            Spacer(modifier = Modifier.height(2.dp))
-            Text(
-                text = "v${pkg.version}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-            HorizontalDivider()
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
+            item.sizeBytes?.let {
+                Spacer(modifier = Modifier.height(8.dp))
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(8.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         Icons.Default.Inventory2,
@@ -279,17 +258,68 @@ private fun ArtifactSearchResultCard(pkg: PackageItem) {
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = formatBytes(pkg.sizeBytes),
+                        text = formatBytes(it),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-                Text(
-                    text = "${pkg.downloadCount} downloads",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             }
+        }
+    }
+}
+
+@Composable
+private fun ChecksumRow(item: ChecksumArtifact) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            ItemTitleWithChip(title = item.name, chipLabel = item.contentType)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "${item.repositoryKey} / ${item.path}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = formatBytes(item.sizeBytes),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun CenteredProgress() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun CenteredMessage(message: String, isError: Boolean = false) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(32.dp),
+        ) {
+            if (!isError) {
+                Icon(
+                    Icons.Default.Search,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyLarge,
+                color = if (isError) MaterialTheme.colorScheme.error
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/search/SearchViewModel.kt
@@ -1,0 +1,191 @@
+package com.artifactkeeper.android.ui.screens.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.ChecksumArtifact
+import com.artifactkeeper.client.models.SearchResultItem
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+enum class SearchMode {
+    TEXT,
+    CHECKSUM,
+}
+
+data class SearchUiState(
+    val mode: SearchMode = SearchMode.TEXT,
+    val results: List<SearchResultItem> = emptyList(),
+    val checksumResults: List<ChecksumArtifact> = emptyList(),
+    val suggestions: List<String> = emptyList(),
+    val recent: List<SearchResultItem> = emptyList(),
+    val trending: List<SearchResultItem> = emptyList(),
+    val isSearching: Boolean = false,
+    val hasSearched: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class SearchViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SearchUiState())
+    val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
+
+    /** Loads the recent and trending lists shown before a search is run. */
+    fun loadInitial() {
+        viewModelScope.launch {
+            val recent = runCatchingApi { apiClient.searchApi.recent(RECENT_LIMIT).unwrap() } ?: emptyList()
+            val trending =
+                runCatchingApi { apiClient.searchApi.trending(TRENDING_DAYS, TRENDING_LIMIT).unwrap() } ?: emptyList()
+            _uiState.update { it.copy(recent = recent, trending = trending) }
+        }
+    }
+
+    fun setMode(mode: SearchMode) {
+        _uiState.update {
+            it.copy(
+                mode = mode,
+                results = emptyList(),
+                checksumResults = emptyList(),
+                suggestions = emptyList(),
+                hasSearched = false,
+                error = null,
+            )
+        }
+    }
+
+    fun quickSearch(query: String) {
+        val trimmed = query.trim()
+        if (trimmed.isBlank()) {
+            _uiState.update { it.copy(results = emptyList(), hasSearched = false, error = null) }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSearching = true, error = null) }
+            try {
+                val results = apiClient.searchApi.quickSearch(trimmed, QUICK_LIMIT, null).unwrap().results
+                _uiState.update {
+                    it.copy(
+                        results = results,
+                        suggestions = emptyList(),
+                        isSearching = false,
+                        hasSearched = true,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(isSearching = false, hasSearched = true, error = e.message ?: "Search failed")
+                }
+            }
+        }
+    }
+
+    fun loadSuggestions(prefix: String) {
+        val trimmed = prefix.trim()
+        if (trimmed.length < MIN_SUGGEST_PREFIX) {
+            _uiState.update { it.copy(suggestions = emptyList()) }
+            return
+        }
+        viewModelScope.launch {
+            val suggestions =
+                runCatchingApi { apiClient.searchApi.suggest(trimmed, SUGGEST_LIMIT).unwrap()?.suggestions }
+                    ?: emptyList()
+            _uiState.update { it.copy(suggestions = suggestions) }
+        }
+    }
+
+    fun checksumSearch(checksum: String, algorithm: String? = null) {
+        val trimmed = checksum.trim()
+        if (trimmed.isBlank()) {
+            _uiState.update { it.copy(checksumResults = emptyList(), hasSearched = false, error = null) }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSearching = true, error = null) }
+            try {
+                val artifacts = apiClient.searchApi.checksumSearch(trimmed, algorithm).unwrap().artifacts
+                _uiState.update {
+                    it.copy(checksumResults = artifacts, isSearching = false, hasSearched = true)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(isSearching = false, hasSearched = true, error = e.message ?: "Checksum search failed")
+                }
+            }
+        }
+    }
+
+    fun advancedSearch(
+        query: String? = null,
+        format: String? = null,
+        repositoryKey: String? = null,
+        minSize: Long? = null,
+        maxSize: Long? = null,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSearching = true, error = null) }
+            try {
+                val response = apiClient.searchApi.advancedSearch(
+                    query = query?.trim()?.ifBlank { null },
+                    format = format,
+                    repositoryKey = repositoryKey,
+                    name = null,
+                    path = null,
+                    version = null,
+                    minSize = minSize,
+                    maxSize = maxSize,
+                    createdAfter = null,
+                    createdBefore = null,
+                    page = 1,
+                    perPage = ADVANCED_PER_PAGE,
+                    sortBy = null,
+                    sortOrder = null,
+                ).unwrap()
+                _uiState.update {
+                    it.copy(results = response.items, isSearching = false, hasSearched = true)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(isSearching = false, hasSearched = true, error = e.message ?: "Search failed")
+                }
+            }
+        }
+    }
+
+    fun clear() {
+        _uiState.update {
+            it.copy(
+                results = emptyList(),
+                checksumResults = emptyList(),
+                suggestions = emptyList(),
+                hasSearched = false,
+                error = null,
+            )
+        }
+    }
+
+    private inline fun <T> runCatchingApi(block: () -> T?): T? =
+        try {
+            block()
+        } catch (_: Exception) {
+            null
+        }
+
+    private companion object {
+        const val QUICK_LIMIT = 25L
+        const val SUGGEST_LIMIT = 8L
+        const val RECENT_LIMIT = 10L
+        const val TRENDING_LIMIT = 10L
+        const val TRENDING_DAYS = 7
+        const val ADVANCED_PER_PAGE = 20
+        const val MIN_SUGGEST_PREFIX = 2
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/SearchViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/SearchViewModelTest.kt
@@ -1,0 +1,275 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.search.SearchMode
+import com.artifactkeeper.android.ui.screens.search.SearchUiState
+import com.artifactkeeper.android.ui.screens.search.SearchViewModel
+import com.artifactkeeper.client.apis.SearchApi
+import com.artifactkeeper.client.models.ChecksumArtifact
+import com.artifactkeeper.client.models.ChecksumSearchResponse
+import com.artifactkeeper.client.models.QuickSearchResponse
+import com.artifactkeeper.client.models.SearchResultItem
+import com.artifactkeeper.client.models.SuggestResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockSearchApi = mockk<SearchApi>(relaxed = false)
+    private val mockApiClient = mockk<ApiClient> {
+        every { searchApi } returns mockSearchApi
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is empty text mode`() {
+        val vm = SearchViewModel(mockApiClient)
+        val state = vm.uiState.value
+        assertEquals(SearchUiState(), state)
+        assertEquals(SearchMode.TEXT, state.mode)
+        assertFalse(state.hasSearched)
+        assertTrue(state.results.isEmpty())
+    }
+
+    @Test
+    fun `loadInitial populates recent and trending`() {
+        coEvery { mockSearchApi.recent(any()) } returns Response.success(listOf(item("recent-pkg")))
+        coEvery { mockSearchApi.trending(any(), any()) } returns Response.success(listOf(item("trending-pkg")))
+        val vm = SearchViewModel(mockApiClient)
+
+        vm.loadInitial()
+
+        val state = vm.uiState.value
+        assertEquals(1, state.recent.size)
+        assertEquals("recent-pkg", state.recent.first().name)
+        assertEquals(1, state.trending.size)
+        assertEquals("trending-pkg", state.trending.first().name)
+    }
+
+    @Test
+    fun `loadInitial tolerates recent and trending failures`() {
+        coEvery { mockSearchApi.recent(any()) } throws RuntimeException("nope")
+        coEvery { mockSearchApi.trending(any(), any()) } throws RuntimeException("nope")
+        val vm = SearchViewModel(mockApiClient)
+
+        vm.loadInitial()
+
+        assertNull(vm.uiState.value.error)
+        assertTrue(vm.uiState.value.recent.isEmpty())
+        assertTrue(vm.uiState.value.trending.isEmpty())
+    }
+
+    @Test
+    fun `quickSearch populates results and marks searched`() {
+        coEvery { mockSearchApi.quickSearch("lib", any(), any()) } returns
+            Response.success(QuickSearchResponse(results = listOf(item("libfoo"), item("libbar"))))
+        val vm = SearchViewModel(mockApiClient)
+
+        vm.quickSearch("lib")
+
+        val state = vm.uiState.value
+        assertFalse(state.isSearching)
+        assertTrue(state.hasSearched)
+        assertEquals(2, state.results.size)
+        coVerify { mockSearchApi.quickSearch("lib", any(), any()) }
+    }
+
+    @Test
+    fun `quickSearch with blank query clears results and does not call the api`() {
+        val vm = SearchViewModel(mockApiClient)
+
+        vm.quickSearch("   ")
+
+        assertTrue(vm.uiState.value.results.isEmpty())
+        assertFalse(vm.uiState.value.hasSearched)
+        coVerify(exactly = 0) { mockSearchApi.quickSearch(any(), any(), any()) }
+    }
+
+    @Test
+    fun `quickSearch sets error on failure`() {
+        coEvery { mockSearchApi.quickSearch(any(), any(), any()) } returns Response.error(500, errorBody())
+        val vm = SearchViewModel(mockApiClient)
+
+        vm.quickSearch("lib")
+
+        assertEquals(true, vm.uiState.value.error?.isNotBlank())
+        assertTrue(vm.uiState.value.hasSearched)
+    }
+
+    @Test
+    fun `loadSuggestions populates suggestions`() {
+        coEvery { mockSearchApi.suggest("lo", any()) } returns
+            Response.success(SuggestResponse(suggestions = listOf("log4j", "logback")))
+        val vm = SearchViewModel(mockApiClient)
+
+        vm.loadSuggestions("lo")
+
+        assertEquals(listOf("log4j", "logback"), vm.uiState.value.suggestions)
+    }
+
+    @Test
+    fun `loadSuggestions clears suggestions for short prefix`() {
+        val vm = SearchViewModel(mockApiClient)
+
+        vm.loadSuggestions("")
+
+        assertTrue(vm.uiState.value.suggestions.isEmpty())
+        coVerify(exactly = 0) { mockSearchApi.suggest(any(), any()) }
+    }
+
+    @Test
+    fun `setMode to checksum clears text results`() {
+        coEvery { mockSearchApi.quickSearch(any(), any(), any()) } returns
+            Response.success(QuickSearchResponse(results = listOf(item("libfoo"))))
+        val vm = SearchViewModel(mockApiClient)
+        vm.quickSearch("lib")
+
+        vm.setMode(SearchMode.CHECKSUM)
+
+        val state = vm.uiState.value
+        assertEquals(SearchMode.CHECKSUM, state.mode)
+        assertTrue(state.results.isEmpty())
+        assertFalse(state.hasSearched)
+    }
+
+    @Test
+    fun `checksumSearch populates checksum results`() {
+        coEvery { mockSearchApi.checksumSearch("abc123", any()) } returns
+            Response.success(ChecksumSearchResponse(artifacts = listOf(checksumArtifact("match.jar"))))
+        val vm = SearchViewModel(mockApiClient)
+        vm.setMode(SearchMode.CHECKSUM)
+
+        vm.checksumSearch("abc123")
+
+        val state = vm.uiState.value
+        assertTrue(state.hasSearched)
+        assertEquals(1, state.checksumResults.size)
+        assertEquals("match.jar", state.checksumResults.first().name)
+    }
+
+    @Test
+    fun `checksumSearch with blank input does not call the api`() {
+        val vm = SearchViewModel(mockApiClient)
+        vm.setMode(SearchMode.CHECKSUM)
+
+        vm.checksumSearch("  ")
+
+        coVerify(exactly = 0) { mockSearchApi.checksumSearch(any(), any()) }
+    }
+
+    @Test
+    fun `advancedSearch applies filters and populates results`() {
+        coEvery {
+            mockSearchApi.advancedSearch(
+                query = "lib",
+                format = "maven",
+                repositoryKey = null,
+                name = null,
+                path = null,
+                version = null,
+                minSize = null,
+                maxSize = null,
+                createdAfter = null,
+                createdBefore = null,
+                page = any(),
+                perPage = any(),
+                sortBy = null,
+                sortOrder = null,
+            )
+        } returns Response.success(
+            com.artifactkeeper.client.models.AdvancedSearchResponse(
+                facets = com.artifactkeeper.client.models.FacetsResponse(
+                    contentTypes = emptyList(),
+                    formats = emptyList(),
+                    repositories = emptyList(),
+                ),
+                items = listOf(item("libfoo")),
+                pagination = com.artifactkeeper.client.models.PaginationInfo(
+                    page = 1,
+                    perPage = 20,
+                    total = 1L,
+                    totalPages = 1,
+                ),
+            ),
+        )
+        val vm = SearchViewModel(mockApiClient)
+
+        vm.advancedSearch(query = "lib", format = "maven")
+
+        assertEquals(1, vm.uiState.value.results.size)
+        assertTrue(vm.uiState.value.hasSearched)
+    }
+
+    @Test
+    fun `clear resets query and results`() {
+        coEvery { mockSearchApi.quickSearch(any(), any(), any()) } returns
+            Response.success(QuickSearchResponse(results = listOf(item("libfoo"))))
+        val vm = SearchViewModel(mockApiClient)
+        vm.quickSearch("lib")
+
+        vm.clear()
+
+        val state = vm.uiState.value
+        assertTrue(state.results.isEmpty())
+        assertTrue(state.suggestions.isEmpty())
+        assertFalse(state.hasSearched)
+    }
+
+    // Helpers
+
+    private fun item(name: String) = SearchResultItem(
+        createdAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+        id = UUID.randomUUID(),
+        name = name,
+        repositoryKey = "maven-local",
+        type = "artifact",
+        format = "maven",
+        version = "1.0",
+        sizeBytes = 1024,
+    )
+
+    private fun checksumArtifact(name: String) = ChecksumArtifact(
+        checksumSha256 = "abc123",
+        contentType = "application/java-archive",
+        createdAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+        downloadCount = 3,
+        id = UUID.randomUUID(),
+        name = name,
+        path = "com/example/$name",
+        repositoryKey = "maven-local",
+        sizeBytes = 2048,
+        version = "1.0",
+    )
+
+    private fun errorBody() = "{\"error\":\"boom\"}".toResponseBody("application/json".toMediaType())
+}


### PR DESCRIPTION
## Summary
Upgrades the Search screen (Artifacts cluster 3) to use the dedicated 1.2.1 search endpoints instead of listing repositories and packages.

Covered operations: `quick_search`, `advanced_search`, `suggest`, `recent`, `trending`, `checksum_search`.

Implementation:
- `SearchViewModel` (Hilt): debounced `quick_search`, `suggest` autocomplete, `checksum_search` (checksum mode), `recent` + `trending` for the initial state, and `advanced_search` for filtered queries. Recent/trending failures are tolerated so the screen still renders.
- `SearchScreen` (Material 3): text/checksum mode toggle (segmented buttons), suggestion chips, recent/trending initial view, unified result rows, and loading/error/empty states. Debounce lives in the screen; the ViewModel exposes explicit calls so the logic is unit-testable.
- `searchApi` wired into `ApiClient`.

Closes #102
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New: `SearchViewModelTest` (13 tests) covering initial state, recent/trending load and failure tolerance, quick search success/blank/error, suggestion load and short-prefix guard, mode switch clearing, checksum search success/blank, advanced search with filters, and clear. Full unit suite green: 699 tests, 0 failures. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both pass.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes