### PR TITLE
feat(security): quality health, gates, and issue suppression

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -13,6 +13,7 @@ import com.artifactkeeper.client.apis.MonitoringApi
 import com.artifactkeeper.client.apis.PackagesApi
 import com.artifactkeeper.client.apis.PeersApi
 import com.artifactkeeper.client.apis.PromotionApi
+import com.artifactkeeper.client.apis.QualityApi
 import com.artifactkeeper.client.apis.RepositoriesApi
 import com.artifactkeeper.client.apis.SbomApi
 import com.artifactkeeper.client.apis.SecurityApi
@@ -68,6 +69,7 @@ object ApiClient {
     lateinit var signingApi: SigningApi private set
     lateinit var ssoApi: SsoApi private set
     lateinit var promotionApi: PromotionApi private set
+    lateinit var qualityApi: QualityApi private set
     lateinit var stagingApi: StagingApi private set
 
     // Keep a raw OkHttpClient for cases that need direct HTTP access
@@ -133,6 +135,7 @@ object ApiClient {
         signingApi = client.createService(SigningApi::class.java)
         ssoApi = client.createService(SsoApi::class.java)
         promotionApi = client.createService(PromotionApi::class.java)
+        qualityApi = client.createService(QualityApi::class.java)
         stagingApi = client.createService(StagingApi::class.java)
     }
 

--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -67,6 +67,8 @@ import com.artifactkeeper.android.ui.screens.security.LicensePoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.PoliciesScreen
 import com.artifactkeeper.android.ui.screens.security.RepoSecurityScreen
 import com.artifactkeeper.android.ui.screens.security.ScanDetailScreen
+import com.artifactkeeper.android.ui.screens.security.QualityArtifactScreen
+import com.artifactkeeper.android.ui.screens.security.QualityHealthScreen
 import com.artifactkeeper.android.ui.screens.security.ScansScreen
 import com.artifactkeeper.android.ui.screens.security.SigningKeysScreen
 import com.artifactkeeper.android.ui.screens.security.SecurityScreen
@@ -597,7 +599,7 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SecuritySection(isCompact: Boolean, accountActions: @Composable () -> Unit) {
-    val subTabs = listOf("Dashboard", "Scans", "Dep-Track", "Policies", "Licenses", "Signing")
+    val subTabs = listOf("Dashboard", "Scans", "Dep-Track", "Policies", "Licenses", "Signing", "Quality")
     var selectedTab by remember { mutableIntStateOf(0) }
     var selectedScanId by remember { mutableStateOf<String?>(null) }
     var selectedDtProject by remember { mutableStateOf<Pair<String, String>?>(null) }
@@ -641,6 +643,7 @@ private fun SecuritySection(isCompact: Boolean, accountActions: @Composable () -
                 3 -> PoliciesScreen()
                 4 -> LicensePoliciesScreen()
                 5 -> SigningKeysScreen()
+                6 -> QualityHealthScreen()
             }
         }
     }
@@ -760,6 +763,14 @@ private fun NavGraphBuilder.detailRoutes(navController: NavHostController) {
             artifactId = id,
             onScanClick = { scanId -> navController.navigate("artifacts/$id/security/scans/$scanId") },
             onViewCves = { navController.navigate("artifacts/$id/cves") },
+            onViewQuality = { navController.navigate("artifacts/$id/quality") },
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable("artifacts/{id}/quality") { backStackEntry ->
+        val id = backStackEntry.arguments?.getString("id") ?: return@composable
+        QualityArtifactScreen(
+            artifactId = id,
             onBack = { navController.popBackStack() },
         )
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityScreen.kt
@@ -51,6 +51,7 @@ fun ArtifactSecurityScreen(
     onScanClick: (String) -> Unit,
     onBack: () -> Unit,
     onViewCves: () -> Unit = {},
+    onViewQuality: () -> Unit = {},
     viewModel: ArtifactSecurityViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -72,6 +73,9 @@ fun ArtifactSecurityScreen(
                 }
             },
             actions = {
+                TextButton(onClick = onViewQuality) {
+                    Text("Quality")
+                }
                 TextButton(onClick = onViewCves) {
                     Text("CVEs")
                 }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityArtifactScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityArtifactScreen.kt
@@ -1,0 +1,347 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.android.ui.theme.Critical
+import com.artifactkeeper.android.ui.theme.High
+import com.artifactkeeper.android.ui.theme.Low
+import com.artifactkeeper.android.ui.theme.Medium
+import com.artifactkeeper.client.models.ArtifactHealthResponse
+import com.artifactkeeper.client.models.IssueResponse
+import java.util.UUID
+
+/**
+ * Per-artifact quality detail: a health summary plus the issues found by quality
+ * checks, each of which can be suppressed (with a reason) or unsuppressed.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QualityArtifactScreen(
+    artifactId: String,
+    onBack: () -> Unit,
+    viewModel: QualityViewModel = hiltViewModel(),
+) {
+    val state by viewModel.artifactState.collectAsState()
+    val parsedId = remember(artifactId) { runCatching { UUID.fromString(artifactId) }.getOrNull() }
+    var issueToSuppress by remember { mutableStateOf<IssueResponse?>(null) }
+
+    LaunchedEffect(parsedId) {
+        parsedId?.let { viewModel.loadArtifactQuality(it) }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("Artifact Quality") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            },
+        )
+
+        when {
+            parsedId == null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = "Invalid artifact id",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.error != null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.loadArtifactQuality(parsedId) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            else -> {
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    state.health?.let { health ->
+                        item { ArtifactHealthCard(health) }
+                    }
+
+                    item {
+                        Text(
+                            text = "Issues (${state.issues.size})",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
+                    if (state.issues.isEmpty()) {
+                        item {
+                            Text(
+                                text = "No quality issues found",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    } else {
+                        items(state.issues, key = { it.id }) { issue ->
+                            QualityIssueCard(
+                                issue = issue,
+                                isMutating = state.isMutating,
+                                onSuppress = { issueToSuppress = issue },
+                                onUnsuppress = { viewModel.unsuppressIssue(parsedId, issue.id) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    issueToSuppress?.let { issue ->
+        SuppressIssueDialog(
+            issueTitle = issue.title,
+            isMutating = state.isMutating,
+            onConfirm = { reason ->
+                parsedId?.let { viewModel.suppressIssue(it, issue.id, reason) }
+                issueToSuppress = null
+            },
+            onDismiss = { issueToSuppress = null },
+        )
+    }
+}
+
+@Composable
+private fun ArtifactHealthCard(health: ArtifactHealthResponse) {
+    val color = gradeColor(health.healthGrade)
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text(
+                        text = "Health Score",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = "${health.healthScore}/100  -  ${health.checksPassed}/${health.checksTotal} checks passed",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(color),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = health.healthGrade.uppercase(),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                health.qualityScore?.let { SubScorePill("Quality", it) }
+                health.securityScore?.let { SubScorePill("Security", it) }
+                health.licenseScore?.let { SubScorePill("License", it) }
+                health.metadataScore?.let { SubScorePill("Metadata", it) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SubScorePill(label: String, score: Int) {
+    val color = when {
+        score >= 80 -> GradeAColor
+        score >= 60 -> GradeCColor
+        else -> GradeFColor
+    }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(color.copy(alpha = 0.12f))
+            .padding(horizontal = 8.dp, vertical = 6.dp),
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = score.toString(),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                color = color,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = color.copy(alpha = 0.8f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun QualityIssueCard(
+    issue: IssueResponse,
+    isMutating: Boolean,
+    onSuppress: () -> Unit,
+    onUnsuppress: () -> Unit,
+) {
+    val sevColor = when (issue.severity.lowercase()) {
+        "critical" -> Critical
+        "high" -> High
+        "medium" -> Medium
+        "low" -> Low
+        else -> Low
+    }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(sevColor.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = issue.severity.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = sevColor,
+                    )
+                }
+                Text(
+                    text = issue.category,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (issue.isSuppressed) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        Text(
+                            text = "Suppressed",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = issue.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            issue.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            issue.location?.takeIf { it.isNotBlank() }?.let { loc ->
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = loc,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
+                if (issue.isSuppressed) {
+                    TextButton(onClick = onUnsuppress, enabled = !isMutating) { Text("Unsuppress") }
+                } else {
+                    TextButton(onClick = onSuppress, enabled = !isMutating) { Text("Suppress") }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SuppressIssueDialog(
+    issueTitle: String,
+    isMutating: Boolean,
+    onConfirm: (reason: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var reason by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Suppress issue") },
+        text = {
+            Column {
+                Text(
+                    text = issueTitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = reason,
+                    onValueChange = { reason = it },
+                    label = { Text("Reason") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(reason.trim()) },
+                enabled = !isMutating && reason.isNotBlank(),
+            ) {
+                Text("Suppress")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityHealthScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityHealthScreen.kt
@@ -1,0 +1,254 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.GateResponse
+import com.artifactkeeper.client.models.HealthDashboardResponse
+import com.artifactkeeper.client.models.RepoHealthResponse
+
+internal val GradeAColor = Color(0xFF52C41A)
+internal val GradeBColor = Color(0xFF36CFC9)
+internal val GradeCColor = Color(0xFFFAAD14)
+internal val GradeDColor = Color(0xFFFA8C16)
+internal val GradeFColor = Color(0xFFF5222D)
+
+internal fun gradeColor(grade: String): Color = when (grade.uppercase()) {
+    "A" -> GradeAColor
+    "B" -> GradeBColor
+    "C" -> GradeCColor
+    "D" -> GradeDColor
+    else -> GradeFColor
+}
+
+/**
+ * Quality health overview: portfolio health dashboard (average score, grade
+ * distribution, per-repo health) and the configured quality gates.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QualityHealthScreen(
+    viewModel: QualityViewModel = hiltViewModel(),
+) {
+    val state by viewModel.healthState.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadHealth() }
+
+    when {
+        state.isLoading -> {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+        state.error != null -> {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = state.error ?: "Unknown error",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    TextButton(onClick = { viewModel.loadHealth(refresh = true) }) {
+                        Text("Retry")
+                    }
+                }
+            }
+        }
+        else -> {
+            LazyColumn(
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                state.dashboard?.let { dashboard ->
+                    item { HealthDashboardCard(dashboard) }
+
+                    if (dashboard.repositories.isNotEmpty()) {
+                        item {
+                            Text(
+                                text = "Repository Health",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                        items(dashboard.repositories, key = { it.repositoryId }) { repo ->
+                            RepoHealthCard(repo)
+                        }
+                    }
+                }
+
+                if (state.gates.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = "Quality Gates (${state.gates.size})",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
+                    items(state.gates, key = { it.id }) { gate ->
+                        QualityGateCard(gate)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HealthDashboardCard(dashboard: HealthDashboardResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text(
+                        text = "Health Overview",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = "${dashboard.totalArtifactsEvaluated} artifacts across ${dashboard.totalRepositories} repos",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = "${dashboard.avgHealthScore}",
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = when {
+                        dashboard.avgHealthScore >= 80 -> GradeAColor
+                        dashboard.avgHealthScore >= 60 -> GradeCColor
+                        else -> GradeFColor
+                    },
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                GradePill("A", dashboard.reposGradeA, GradeAColor)
+                GradePill("B", dashboard.reposGradeB, GradeBColor)
+                GradePill("C", dashboard.reposGradeC, GradeCColor)
+                GradePill("D", dashboard.reposGradeD, GradeDColor)
+                GradePill("F", dashboard.reposGradeF, GradeFColor)
+            }
+        }
+    }
+}
+
+@Composable
+private fun GradePill(label: String, count: Long, color: Color) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = "$label: $count",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+private fun RepoHealthCard(repo: RepoHealthResponse) {
+    val color = gradeColor(repo.healthGrade)
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = repo.repositoryKey,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = "${repo.artifactsPassing} passing, ${repo.artifactsFailing} failing of ${repo.artifactsEvaluated}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(color),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = repo.healthGrade.uppercase(),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun QualityGateCard(gate: GateResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = gate.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                val statusColor = if (gate.isEnabled) GradeAColor else MaterialTheme.colorScheme.onSurfaceVariant
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(statusColor.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = if (gate.isEnabled) "Enabled" else "Disabled",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = statusColor,
+                    )
+                }
+            }
+            gate.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "Action: ${gate.action.replaceFirstChar { it.uppercase() }}  -  Checks: ${gate.requiredChecks.joinToString(", ")}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityViewModel.kt
@@ -1,0 +1,174 @@
+package com.artifactkeeper.android.ui.screens.security
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.ArtifactHealthResponse
+import com.artifactkeeper.client.models.CheckResponse
+import com.artifactkeeper.client.models.GateResponse
+import com.artifactkeeper.client.models.HealthDashboardResponse
+import com.artifactkeeper.client.models.IssueResponse
+import com.artifactkeeper.client.models.SuppressIssueRequest
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for the quality health overview: the portfolio health dashboard and the
+ * configured quality gates.
+ */
+data class QualityHealthUiState(
+    val dashboard: HealthDashboardResponse? = null,
+    val gates: List<GateResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * State for a single artifact's quality: its health summary, the checks run
+ * against it, and the issues those checks found.
+ */
+data class QualityArtifactUiState(
+    val health: ArtifactHealthResponse? = null,
+    val checks: List<CheckResponse> = emptyList(),
+    val issues: List<IssueResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class QualityViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _healthState = MutableStateFlow(QualityHealthUiState())
+    val healthState: StateFlow<QualityHealthUiState> = _healthState.asStateFlow()
+
+    private val _artifactState = MutableStateFlow(QualityArtifactUiState())
+    val artifactState: StateFlow<QualityArtifactUiState> = _artifactState.asStateFlow()
+
+    /**
+     * Load the portfolio health dashboard and the quality gates. Gates are
+     * optional: a deployment may not define any, so a failure there does not
+     * fail the screen.
+     */
+    fun loadHealth(refresh: Boolean = false) {
+        viewModelScope.launch {
+            _healthState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val dashboard = apiClient.qualityApi.getHealthDashboard().unwrap()
+
+                var gates: List<GateResponse> = emptyList()
+                try {
+                    gates = apiClient.qualityApi.listGates().unwrap()
+                } catch (_: Exception) {
+                    // No quality gates configured.
+                }
+
+                _healthState.update {
+                    it.copy(
+                        dashboard = dashboard,
+                        gates = gates,
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _healthState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load quality health",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Load a single artifact's health, its checks, and the issues across those
+     * checks (most severe first).
+     */
+    fun loadArtifactQuality(artifactId: UUID) {
+        viewModelScope.launch {
+            _artifactState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val health = apiClient.qualityApi.getArtifactHealth(artifactId).unwrap()
+                val checks = apiClient.qualityApi.listChecks(artifactId, null).unwrap()
+
+                val issues = mutableListOf<IssueResponse>()
+                for (check in checks) {
+                    try {
+                        issues += apiClient.qualityApi.listCheckIssues(check.id).unwrap()
+                    } catch (_: Exception) {
+                        // Skip checks whose issues cannot be loaded.
+                    }
+                }
+                issues.sortBy { qualityIssueSeverityRank(it.severity) }
+
+                _artifactState.update {
+                    it.copy(health = health, checks = checks, issues = issues, isLoading = false)
+                }
+            } catch (e: Exception) {
+                _artifactState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load artifact quality",
+                        isLoading = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun suppressIssue(artifactId: UUID, issueId: UUID, reason: String) {
+        viewModelScope.launch {
+            _artifactState.update { it.copy(isMutating = true, error = null) }
+            try {
+                apiClient.qualityApi.suppressIssue(issueId, SuppressIssueRequest(reason = reason)).unwrap()
+                _artifactState.update { it.copy(isMutating = false) }
+                loadArtifactQuality(artifactId)
+            } catch (e: Exception) {
+                _artifactState.update {
+                    it.copy(error = e.message ?: "Failed to suppress issue", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun unsuppressIssue(artifactId: UUID, issueId: UUID) {
+        viewModelScope.launch {
+            _artifactState.update { it.copy(isMutating = true, error = null) }
+            try {
+                apiClient.qualityApi.unsuppressIssue(issueId).unwrap()
+                _artifactState.update { it.copy(isMutating = false) }
+                loadArtifactQuality(artifactId)
+            } catch (e: Exception) {
+                _artifactState.update {
+                    it.copy(error = e.message ?: "Failed to unsuppress issue", isMutating = false)
+                }
+            }
+        }
+    }
+
+    companion object {
+        /** Lower rank sorts first, so critical issues appear at the top. */
+        fun qualityIssueSeverityRank(severity: String): Int = when (severity.lowercase()) {
+            "critical" -> 0
+            "high" -> 1
+            "medium" -> 2
+            "low" -> 3
+            else -> 4
+        }
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/QualityViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/QualityViewModelTest.kt
@@ -1,0 +1,271 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.security.QualityHealthUiState
+import com.artifactkeeper.android.ui.screens.security.QualityArtifactUiState
+import com.artifactkeeper.android.ui.screens.security.QualityViewModel
+import com.artifactkeeper.client.apis.QualityApi
+import com.artifactkeeper.client.models.ArtifactHealthResponse
+import com.artifactkeeper.client.models.CheckResponse
+import com.artifactkeeper.client.models.GateResponse
+import com.artifactkeeper.client.models.HealthDashboardResponse
+import com.artifactkeeper.client.models.IssueResponse
+import com.artifactkeeper.client.models.RepoHealthResponse
+import com.artifactkeeper.client.models.SuppressIssueRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class QualityViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockQualityApi = mockk<QualityApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { qualityApi } returns mockQualityApi
+    }
+
+    private val artifactId = UUID.randomUUID()
+    private val repoId = UUID.randomUUID()
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun repoHealth(key: String, grade: String) = RepoHealthResponse(
+        artifactsEvaluated = 10,
+        artifactsFailing = 2,
+        artifactsPassing = 8,
+        healthGrade = grade,
+        healthScore = 80,
+        repositoryId = UUID.randomUUID(),
+        repositoryKey = key,
+    )
+
+    private fun dashboard() = HealthDashboardResponse(
+        avgHealthScore = 78,
+        reposGradeA = 2,
+        reposGradeB = 3,
+        reposGradeC = 1,
+        reposGradeD = 0,
+        reposGradeF = 1,
+        repositories = listOf(repoHealth("maven", "A"), repoHealth("npm", "C")),
+        totalArtifactsEvaluated = 100,
+        totalRepositories = 7,
+    )
+
+    private fun gate(name: String) = GateResponse(
+        action = "block",
+        createdAt = now,
+        enforceOnDownload = true,
+        enforceOnPromotion = true,
+        id = UUID.randomUUID(),
+        isEnabled = true,
+        name = name,
+        requiredChecks = listOf("license", "metadata"),
+        updatedAt = now,
+    )
+
+    private fun check(id: UUID = UUID.randomUUID()) = CheckResponse(
+        artifactId = artifactId,
+        checkType = "metadata",
+        createdAt = now,
+        criticalCount = 0,
+        highCount = 1,
+        id = id,
+        infoCount = 0,
+        issuesCount = 2,
+        lowCount = 1,
+        mediumCount = 0,
+        repositoryId = repoId,
+        status = "completed",
+    )
+
+    private fun artifactHealth() = ArtifactHealthResponse(
+        artifactId = artifactId,
+        checks = emptyList(),
+        checksPassed = 3,
+        checksTotal = 4,
+        criticalIssues = 0,
+        healthGrade = "B",
+        healthScore = 82,
+        totalIssues = 3,
+    )
+
+    private fun issue(suppressed: Boolean = false) = IssueResponse(
+        artifactId = artifactId,
+        category = "metadata",
+        checkResultId = UUID.randomUUID(),
+        createdAt = now,
+        id = UUID.randomUUID(),
+        isSuppressed = suppressed,
+        severity = "high",
+        title = "Missing license",
+    )
+
+    // =========================================================================
+    // UI state
+    // =========================================================================
+
+    @Test
+    fun `initial health state is empty`() {
+        val state = QualityHealthUiState()
+        assertNull(state.dashboard)
+        assertTrue(state.gates.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `initial artifact state is empty`() {
+        val state = QualityArtifactUiState()
+        assertNull(state.health)
+        assertTrue(state.checks.isEmpty())
+        assertTrue(state.issues.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    // =========================================================================
+    // loadHealth
+    // =========================================================================
+
+    @Test
+    fun `loadHealth populates dashboard and gates`() = runTest {
+        coEvery { mockQualityApi.getHealthDashboard() } returns Response.success(dashboard())
+        coEvery { mockQualityApi.listGates() } returns Response.success(listOf(gate("Release Gate")))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.loadHealth()
+
+        val state = vm.healthState.value
+        assertNotNull(state.dashboard)
+        assertEquals(1, state.gates.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadHealth tolerates missing gates`() = runTest {
+        coEvery { mockQualityApi.getHealthDashboard() } returns Response.success(dashboard())
+        coEvery { mockQualityApi.listGates() } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "no gates"))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.loadHealth()
+
+        assertNotNull(vm.healthState.value.dashboard)
+        assertTrue(vm.healthState.value.gates.isEmpty())
+        assertNull(vm.healthState.value.error)
+    }
+
+    @Test
+    fun `loadHealth sets error when dashboard fails`() = runTest {
+        coEvery { mockQualityApi.getHealthDashboard() } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.loadHealth()
+
+        assertNotNull(vm.healthState.value.error)
+        assertFalse(vm.healthState.value.isLoading)
+    }
+
+    // =========================================================================
+    // loadArtifactQuality
+    // =========================================================================
+
+    @Test
+    fun `loadArtifactQuality aggregates health checks and issues`() = runTest {
+        val checkId = UUID.randomUUID()
+        coEvery { mockQualityApi.getArtifactHealth(artifactId) } returns Response.success(artifactHealth())
+        coEvery { mockQualityApi.listChecks(artifactId, null) } returns Response.success(listOf(check(checkId)))
+        coEvery { mockQualityApi.listCheckIssues(checkId) } returns Response.success(listOf(issue(), issue()))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.loadArtifactQuality(artifactId)
+
+        val state = vm.artifactState.value
+        assertNotNull(state.health)
+        assertEquals(1, state.checks.size)
+        assertEquals(2, state.issues.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadArtifactQuality sets error when health fails`() = runTest {
+        coEvery { mockQualityApi.getArtifactHealth(artifactId) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.loadArtifactQuality(artifactId)
+
+        assertNotNull(vm.artifactState.value.error)
+        assertNull(vm.artifactState.value.health)
+    }
+
+    // =========================================================================
+    // suppress / unsuppress
+    // =========================================================================
+
+    @Test
+    fun `suppressIssue sends reason and reloads artifact quality`() = runTest {
+        val issueId = UUID.randomUUID()
+        coEvery { mockQualityApi.suppressIssue(issueId, any()) } returns Response.success(issue(suppressed = true))
+        coEvery { mockQualityApi.getArtifactHealth(artifactId) } returns Response.success(artifactHealth())
+        coEvery { mockQualityApi.listChecks(artifactId, null) } returns Response.success(emptyList())
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.suppressIssue(artifactId, issueId, "accepted risk")
+
+        coVerify { mockQualityApi.suppressIssue(issueId, SuppressIssueRequest(reason = "accepted risk")) }
+        assertNull(vm.artifactState.value.error)
+    }
+
+    @Test
+    fun `unsuppressIssue calls api`() = runTest {
+        val issueId = UUID.randomUUID()
+        coEvery { mockQualityApi.unsuppressIssue(issueId) } returns Response.success(issue(suppressed = false))
+        coEvery { mockQualityApi.getArtifactHealth(artifactId) } returns Response.success(artifactHealth())
+        coEvery { mockQualityApi.listChecks(artifactId, null) } returns Response.success(emptyList())
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.unsuppressIssue(artifactId, issueId)
+
+        coVerify { mockQualityApi.unsuppressIssue(issueId) }
+    }
+
+    @Test
+    fun `qualityIssueSeverityRank orders critical first`() {
+        assertTrue(
+            QualityViewModel.qualityIssueSeverityRank("critical") <
+                QualityViewModel.qualityIssueSeverityRank("low"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Adds a quality surface to the Security section.

- New "Quality" sub-tab. `QualityHealthScreen` shows the portfolio health dashboard (average score, A-F repo grade distribution, per-repo health cards) and the configured quality gates (action, required checks, enabled state).
- `QualityArtifactScreen` (reachable via a new "Quality" action on `ArtifactSecurityScreen`) shows a per-artifact health summary (grade + quality/security/license/metadata sub-scores) and the issues found by quality checks. Each issue can be suppressed (with a reason via dialog) or unsuppressed.
- `QualityViewModel` is Hilt-injected with loading/error/mutating states. Quality gates are treated as optional so a deployment without them still renders.
- Adds `QualityApi` to the app's `ApiClient`.

Rebased onto current main (after #101 landed). Nav-host reconciled to keep all sub-tabs: Signing (index 5, from #101) and the new Quality (index 6); index math redone. No parity-matrix edits (maintained centrally).

Operations wired (previously missing):
- `get_health_dashboard` (GET /api/v1/quality/health/dashboard)
- `list_gates` (GET /api/v1/quality/gates)
- `get_artifact_health` (GET /api/v1/quality/health/artifacts/{artifact_id})
- `list_checks` (GET /api/v1/quality/checks)
- `list_check_issues` (GET /api/v1/quality/checks/{id}/issues)
- `suppress_issue` (POST /api/v1/quality/issues/{id}/suppress)
- `unsuppress_issue` (DELETE /api/v1/quality/issues/{id}/suppress)

Deferred follow-up (not in this PR): gate authoring (`get_gate`/`create_gate`/`update_gate`/`delete_gate`/`evaluate_gate`), `trigger_checks`, `get_check`, `get_repo_health`.

Closes #104
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`QualityViewModelTest`: 10 tests, all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` both green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes