### PR TITLE
feat(security): finding acknowledge/revoke UI and scan-config dashboard

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ArtifactSecurityViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.artifactkeeper.android.data.api.ApiClient
 import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.AcknowledgeRequest
 import com.artifactkeeper.client.models.ComponentResponse
 import com.artifactkeeper.client.models.FindingResponse
 import com.artifactkeeper.client.models.ScanResponse
@@ -37,7 +38,9 @@ data class ScanDetailUiState(
     val scan: ScanResponse? = null,
     val findings: List<FindingResponse> = emptyList(),
     val isLoading: Boolean = false,
+    val isMutating: Boolean = false,
     val error: String? = null,
+    val message: String? = null,
 )
 
 @HiltViewModel
@@ -117,6 +120,50 @@ class ArtifactSecurityViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * Acknowledge a finding with a reason, then reload the scan so the finding's
+     * acknowledged state is reflected.
+     */
+    fun acknowledgeFinding(scanId: UUID, findingId: UUID, reason: String) {
+        viewModelScope.launch {
+            _scanDetailState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.securityApi.acknowledgeFinding(
+                    findingId,
+                    AcknowledgeRequest(reason = reason),
+                ).unwrap()
+                _scanDetailState.update { it.copy(isMutating = false, message = "Finding acknowledged") }
+                loadScanDetail(scanId)
+            } catch (e: Exception) {
+                _scanDetailState.update {
+                    it.copy(error = e.message ?: "Failed to acknowledge finding", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /**
+     * Revoke a finding's acknowledgment, then reload the scan.
+     */
+    fun revokeAcknowledgment(scanId: UUID, findingId: UUID) {
+        viewModelScope.launch {
+            _scanDetailState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.securityApi.revokeAcknowledgment(findingId).unwrap()
+                _scanDetailState.update { it.copy(isMutating = false, message = "Acknowledgment revoked") }
+                loadScanDetail(scanId)
+            } catch (e: Exception) {
+                _scanDetailState.update {
+                    it.copy(error = e.message ?: "Failed to revoke acknowledgment", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun clearScanDetailMessage() {
+        _scanDetailState.update { it.copy(message = null, error = null) }
     }
 
     companion object {

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/CveTrackingViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/CveTrackingViewModel.kt
@@ -6,7 +6,6 @@ import com.artifactkeeper.android.data.api.ApiClient
 import com.artifactkeeper.android.data.api.unwrap
 import com.artifactkeeper.client.models.AcknowledgeRequest
 import com.artifactkeeper.client.models.CveHistoryEntry
-import com.artifactkeeper.client.models.ScanConfigResponse
 import com.artifactkeeper.client.models.UpdateCveStatusRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,12 +17,10 @@ import java.util.UUID
 import javax.inject.Inject
 
 /**
- * State for the CVE tracking list: the CVE history entries for an artifact plus
- * the server's scan configuration.
+ * State for the CVE tracking list: the CVE history entries for an artifact.
  */
 data class CveTrackingUiState(
     val entries: List<CveHistoryEntry> = emptyList(),
-    val scanConfigs: List<ScanConfigResponse> = emptyList(),
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val error: String? = null,
@@ -72,17 +69,6 @@ class CveTrackingViewModel @Inject constructor(
                         isRefreshing = false,
                     )
                 }
-            }
-        }
-    }
-
-    fun loadScanConfigs() {
-        viewModelScope.launch {
-            try {
-                val configs = apiClient.securityApi.listScanConfigs().unwrap()
-                _uiState.update { it.copy(scanConfigs = configs) }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(error = e.message ?: "Failed to load scan configs") }
             }
         }
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScanDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/ScanDetailScreen.kt
@@ -45,12 +45,24 @@ fun ScanDetailScreen(
 ) {
     val state by viewModel.scanDetailState.collectAsState()
     val parsedId = remember(scanId) { runCatching { UUID.fromString(scanId) }.getOrNull() }
+    val snackbarHostState = remember { SnackbarHostState() }
+    var findingToAcknowledge by remember { mutableStateOf<FindingResponse?>(null) }
 
     LaunchedEffect(parsedId) {
         parsedId?.let { viewModel.loadScanDetail(it) }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    // Surface mutation results (acknowledge / revoke) without blanking the list.
+    LaunchedEffect(state.message, state.error, state.scan) {
+        val text = state.message ?: state.error?.takeIf { state.scan != null }
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearScanDetailMessage()
+        }
+    }
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+    Column(modifier = Modifier.fillMaxSize().padding(padding)) {
         TopAppBar(
             title = { Text("Scan Detail") },
             navigationIcon = {
@@ -77,7 +89,7 @@ fun ScanDetailScreen(
                     CircularProgressIndicator()
                 }
             }
-            state.error != null -> {
+            state.error != null && state.scan == null -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(
@@ -119,13 +131,75 @@ fun ScanDetailScreen(
                         }
                     } else {
                         items(state.findings, key = { it.id }) { finding ->
-                            FindingDetailCard(finding)
+                            FindingDetailCard(
+                                finding = finding,
+                                isMutating = state.isMutating,
+                                onAcknowledge = { findingToAcknowledge = finding },
+                                onRevoke = {
+                                    parsedId?.let { viewModel.revokeAcknowledgment(it, finding.id) }
+                                },
+                            )
                         }
                     }
                 }
             }
         }
     }
+    }
+
+    findingToAcknowledge?.let { finding ->
+        AcknowledgeFindingDialog(
+            findingTitle = finding.title,
+            isMutating = state.isMutating,
+            onConfirm = { reason ->
+                parsedId?.let { viewModel.acknowledgeFinding(it, finding.id, reason) }
+                findingToAcknowledge = null
+            },
+            onDismiss = { findingToAcknowledge = null },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AcknowledgeFindingDialog(
+    findingTitle: String,
+    isMutating: Boolean,
+    onConfirm: (reason: String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var reason by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Acknowledge finding") },
+        text = {
+            Column {
+                Text(
+                    text = findingTitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = reason,
+                    onValueChange = { reason = it },
+                    label = { Text("Reason") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(reason.trim()) },
+                enabled = !isMutating && reason.isNotBlank(),
+            ) {
+                Text("Acknowledge")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
 }
 
 @Composable
@@ -189,7 +263,12 @@ private fun ScanSummaryCard(scan: ScanResponse) {
 }
 
 @Composable
-private fun FindingDetailCard(finding: FindingResponse) {
+private fun FindingDetailCard(
+    finding: FindingResponse,
+    isMutating: Boolean = false,
+    onAcknowledge: () -> Unit = {},
+    onRevoke: () -> Unit = {},
+) {
     val uriHandler = LocalUriHandler.current
     val sevColor = severityColor(finding.severity)
 
@@ -311,6 +390,19 @@ private fun FindingDetailCard(finding: FindingResponse) {
                     maxLines = 3,
                     overflow = TextOverflow.Ellipsis,
                 )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
+                if (finding.isAcknowledged) {
+                    TextButton(onClick = onRevoke, enabled = !isMutating) {
+                        Text("Revoke")
+                    }
+                } else {
+                    TextButton(onClick = onAcknowledge, enabled = !isMutating) {
+                        Text("Acknowledge")
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SecurityScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SecurityScreen.kt
@@ -22,6 +22,7 @@ import com.artifactkeeper.android.data.models.DtPortfolioMetrics
 import com.artifactkeeper.android.data.models.DtStatus
 import com.artifactkeeper.android.data.models.RepoSecurityScore
 import com.artifactkeeper.android.data.models.Repository
+import com.artifactkeeper.client.models.ScanConfigResponse
 import com.artifactkeeper.android.ui.theme.Critical
 import com.artifactkeeper.android.ui.theme.High
 import com.artifactkeeper.android.ui.theme.Low
@@ -51,7 +52,7 @@ fun SecurityScreen(
             error = uiState.error,
             onRetry = { viewModel.loadData() },
             emptyState = EmptyState(
-                isEmpty = uiState.scores.isEmpty() && uiState.cveTrends == null && uiState.dtStatus?.enabled != true,
+                isEmpty = uiState.scores.isEmpty() && uiState.cveTrends == null && uiState.dtStatus?.enabled != true && uiState.scanConfigs.isEmpty(),
                 message = "No security data available",
             ),
         ) {
@@ -98,6 +99,19 @@ fun SecurityScreen(
                         }
                         items(uiState.scores, key = { it.id }) { score ->
                             SecurityScoreCard(score, uiState.repoMap[score.repositoryId])
+                        }
+                    }
+
+                    if (uiState.scanConfigs.isNotEmpty()) {
+                        item(key = "scan-configs-header") {
+                            Text(
+                                text = "Scan Configuration",
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                        items(uiState.scanConfigs, key = { it.id }) { config ->
+                            ScanConfigCard(config, uiState.repoMap[config.repositoryId])
                         }
                     }
                 }
@@ -273,6 +287,65 @@ private fun DtAuditProgressCard(metrics: DtPortfolioMetrics) {
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun ScanConfigCard(config: ScanConfigResponse, repo: Repository?) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = repo?.name ?: repo?.key ?: config.repositoryId.toString(),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                val statusColor = if (config.scanEnabled) GradeA else MaterialTheme.colorScheme.onSurfaceVariant
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(statusColor.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = if (config.scanEnabled) "Enabled" else "Disabled",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = statusColor,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            ScanConfigRow("Scan on upload", config.scanOnUpload)
+            ScanConfigRow("Scan on proxy", config.scanOnProxy)
+            ScanConfigRow("Block on policy violation", config.blockOnPolicyViolation)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Severity threshold: ${config.severityThreshold.replaceFirstChar { it.uppercase() }}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScanConfigRow(label: String, enabled: Boolean) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodySmall)
+        Text(
+            text = if (enabled) "On" else "Off",
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.SemiBold,
+            color = if (enabled) GradeA else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SecurityViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SecurityViewModel.kt
@@ -9,6 +9,7 @@ import com.artifactkeeper.android.data.models.DtPortfolioMetrics
 import com.artifactkeeper.android.data.models.DtStatus
 import com.artifactkeeper.android.data.models.RepoSecurityScore
 import com.artifactkeeper.android.data.models.Repository
+import com.artifactkeeper.client.models.ScanConfigResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,6 +24,7 @@ data class SecurityUiState(
     val cveTrends: CveTrends? = null,
     val dtStatus: DtStatus? = null,
     val dtPortfolioMetrics: DtPortfolioMetrics? = null,
+    val scanConfigs: List<ScanConfigResponse> = emptyList(),
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val error: String? = null,
@@ -70,6 +72,13 @@ class SecurityViewModel @Inject constructor(
                     // Dependency-Track is optional
                 }
 
+                var scanConfigs: List<ScanConfigResponse> = emptyList()
+                try {
+                    scanConfigs = apiClient.securityApi.listScanConfigs().unwrap()
+                } catch (_: Exception) {
+                    // Scan configs are optional
+                }
+
                 _uiState.update {
                     it.copy(
                         scores = scores,
@@ -77,6 +86,7 @@ class SecurityViewModel @Inject constructor(
                         cveTrends = cveTrends,
                         dtStatus = dtStatus,
                         dtPortfolioMetrics = dtPortfolioMetrics,
+                        scanConfigs = scanConfigs,
                         isLoading = false,
                         isRefreshing = false,
                     )

--- a/app/src/test/java/com/artifactkeeper/android/ArtifactSecurityViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/ArtifactSecurityViewModelTest.kt
@@ -5,6 +5,7 @@ import com.artifactkeeper.android.ui.screens.security.ArtifactSecurityUiState
 import com.artifactkeeper.android.ui.screens.security.ArtifactSecurityViewModel
 import com.artifactkeeper.client.apis.SbomApi
 import com.artifactkeeper.client.apis.SecurityApi
+import com.artifactkeeper.client.models.AcknowledgeRequest
 import com.artifactkeeper.client.models.ComponentResponse
 import com.artifactkeeper.client.models.FindingListResponse
 import com.artifactkeeper.client.models.FindingResponse
@@ -12,6 +13,7 @@ import com.artifactkeeper.client.models.ScanListResponse
 import com.artifactkeeper.client.models.ScanResponse
 import com.artifactkeeper.client.models.SbomContentResponse
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
@@ -260,5 +262,78 @@ class ArtifactSecurityViewModelTest {
 
         val severities = vm.scanDetailState.value.findings.map { it.severity }
         assertEquals(listOf("critical", "medium", "low"), severities)
+    }
+
+    // =========================================================================
+    // acknowledgeFinding / revokeAcknowledgment
+    // =========================================================================
+
+    @Test
+    fun `acknowledgeFinding sends reason and reloads scan detail`() = runTest {
+        val scanId = UUID.randomUUID()
+        val findingId = UUID.randomUUID()
+        coEvery { mockSecurityApi.acknowledgeFinding(findingId, any()) } returns
+            Response.success(finding("high"))
+        coEvery { mockSecurityApi.getScan(scanId) } returns Response.success(scan(id = scanId))
+        coEvery { mockSecurityApi.listFindings(scanId) } returns Response.success(
+            FindingListResponse(items = listOf(finding("high")), total = 1),
+        )
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.acknowledgeFinding(scanId, findingId, "accepted risk")
+
+        coVerify {
+            mockSecurityApi.acknowledgeFinding(findingId, AcknowledgeRequest(reason = "accepted risk"))
+        }
+        coVerify { mockSecurityApi.listFindings(scanId) }
+        assertFalse(vm.scanDetailState.value.isMutating)
+        assertNull(vm.scanDetailState.value.error)
+    }
+
+    @Test
+    fun `acknowledgeFinding sets error on failure`() = runTest {
+        val scanId = UUID.randomUUID()
+        val findingId = UUID.randomUUID()
+        coEvery { mockSecurityApi.acknowledgeFinding(findingId, any()) } returns
+            Response.error(400, okhttp3.ResponseBody.create(null, "bad"))
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.acknowledgeFinding(scanId, findingId, "reason")
+
+        assertNotNull(vm.scanDetailState.value.error)
+        assertFalse(vm.scanDetailState.value.isMutating)
+    }
+
+    @Test
+    fun `revokeAcknowledgment calls api and reloads scan detail`() = runTest {
+        val scanId = UUID.randomUUID()
+        val findingId = UUID.randomUUID()
+        coEvery { mockSecurityApi.revokeAcknowledgment(findingId) } returns
+            Response.success(finding("high"))
+        coEvery { mockSecurityApi.getScan(scanId) } returns Response.success(scan(id = scanId))
+        coEvery { mockSecurityApi.listFindings(scanId) } returns Response.success(
+            FindingListResponse(items = listOf(finding("high")), total = 1),
+        )
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.revokeAcknowledgment(scanId, findingId)
+
+        coVerify { mockSecurityApi.revokeAcknowledgment(findingId) }
+        coVerify { mockSecurityApi.listFindings(scanId) }
+        assertFalse(vm.scanDetailState.value.isMutating)
+    }
+
+    @Test
+    fun `revokeAcknowledgment sets error on failure`() = runTest {
+        val scanId = UUID.randomUUID()
+        val findingId = UUID.randomUUID()
+        coEvery { mockSecurityApi.revokeAcknowledgment(findingId) } returns
+            Response.error(409, okhttp3.ResponseBody.create(null, "conflict"))
+
+        val vm = ArtifactSecurityViewModel(mockApiClient)
+        vm.revokeAcknowledgment(scanId, findingId)
+
+        assertNotNull(vm.scanDetailState.value.error)
+        assertFalse(vm.scanDetailState.value.isMutating)
     }
 }

--- a/app/src/test/java/com/artifactkeeper/android/CveTrackingViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/CveTrackingViewModelTest.kt
@@ -8,7 +8,6 @@ import com.artifactkeeper.client.apis.SbomApi
 import com.artifactkeeper.client.apis.SecurityApi
 import com.artifactkeeper.client.models.CveHistoryEntry
 import com.artifactkeeper.client.models.FindingResponse
-import com.artifactkeeper.client.models.ScanConfigResponse
 import com.artifactkeeper.client.models.UpdateCveStatusRequest
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -84,18 +83,6 @@ class CveTrackingViewModelTest {
         title = "Some vuln",
     )
 
-    private fun scanConfig() = ScanConfigResponse(
-        blockOnPolicyViolation = true,
-        createdAt = now,
-        id = UUID.randomUUID(),
-        repositoryId = UUID.randomUUID(),
-        scanEnabled = true,
-        scanOnProxy = false,
-        scanOnUpload = true,
-        severityThreshold = "high",
-        updatedAt = now,
-    )
-
     // =========================================================================
     // UI state
     // =========================================================================
@@ -104,7 +91,6 @@ class CveTrackingViewModelTest {
     fun `initial tracking state is empty`() {
         val state = CveTrackingUiState()
         assertTrue(state.entries.isEmpty())
-        assertTrue(state.scanConfigs.isEmpty())
         assertFalse(state.isLoading)
         assertNull(state.error)
     }
@@ -237,22 +223,6 @@ class CveTrackingViewModelTest {
         vm.revokeAcknowledgment(findingId)
 
         coVerify { mockSecurityApi.revokeAcknowledgment(findingId) }
-    }
-
-    // =========================================================================
-    // loadScanConfigs
-    // =========================================================================
-
-    @Test
-    fun `loadScanConfigs populates configs`() = runTest {
-        coEvery { mockSecurityApi.listScanConfigs() } returns Response.success(
-            listOf(scanConfig(), scanConfig()),
-        )
-
-        val vm = CveTrackingViewModel(mockApiClient)
-        vm.loadScanConfigs()
-
-        assertEquals(2, vm.uiState.value.scanConfigs.size)
     }
 
     @Test

--- a/app/src/test/java/com/artifactkeeper/android/SecurityViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/SecurityViewModelTest.kt
@@ -10,6 +10,7 @@ import com.artifactkeeper.client.models.DtPortfolioMetrics
 import com.artifactkeeper.client.models.DtStatusResponse
 import com.artifactkeeper.client.models.Pagination
 import com.artifactkeeper.client.models.RepositoryListResponse
+import com.artifactkeeper.client.models.ScanConfigResponse
 import com.artifactkeeper.client.models.ScoreResponse
 import io.mockk.coEvery
 import io.mockk.every
@@ -300,5 +301,39 @@ class SecurityViewModelTest {
         val state = viewModel.uiState.value
         assertFalse(state.isRefreshing)
         assertNull(state.error)
+    }
+
+    // =========================================================================
+    // scan configs
+    // =========================================================================
+
+    @Test
+    fun `loadData populates scan configs`() = runTest {
+        coEvery { mockSecurityApi.getAllScores() } returns Response.success(emptyList())
+        coEvery { mockReposApi.listRepositories(any(), perPage = 100, any(), any(), any()) } returns Response.success(
+            RepositoryListResponse(
+                items = emptyList(),
+                pagination = Pagination(page = 1, perPage = 100, total = 0, totalPages = 1),
+            )
+        )
+        coEvery { mockSbomApi.getCveTrends(any(), any()) } throws RuntimeException("N/A")
+        coEvery { mockSecurityApi.dtStatus() } throws RuntimeException("N/A")
+        val config = ScanConfigResponse(
+            blockOnPolicyViolation = true,
+            createdAt = OffsetDateTime.now(),
+            id = UUID.randomUUID(),
+            repositoryId = UUID.randomUUID(),
+            scanEnabled = true,
+            scanOnProxy = false,
+            scanOnUpload = true,
+            severityThreshold = "high",
+            updatedAt = OffsetDateTime.now(),
+        )
+        coEvery { mockSecurityApi.listScanConfigs() } returns Response.success(listOf(config))
+
+        val viewModel = SecurityViewModel(mockApiClient)
+        viewModel.loadData()
+
+        assertEquals(1, viewModel.uiState.value.scanConfigs.size)
     }
 }


### PR DESCRIPTION
## Summary
Gives three previously ViewModel-only Security operations a real user-triggerable UI, closing the "ViewModel method with no UI" parity gap.

- `acknowledge_finding` / `revoke_acknowledgment`: finding cards in `ScanDetailScreen` now have Acknowledge (with a reason dialog) and Revoke actions, backed by `ArtifactSecurityViewModel`. Results surface via snackbar; mutation errors are non-destructive (the findings list stays visible, only an initial-load failure is full-screen).
- `list_scan_configs`: the Security dashboard (`SecurityScreen`) gains a Scan Configuration section listing per-repository scan configs (scanning enabled, scan on upload/proxy, block on policy violation, severity threshold), loaded by `SecurityViewModel` (optional, like CVE trends).
- Removes the now-redundant ViewModel-only `loadScanConfigs`/`scanConfigs` from `CveTrackingViewModel` (and its test).

Rebased onto current main (after #105 landed). No nav-host changes; no parity-matrix edits (maintained centrally).

Operations given a UI surface (previously ViewModel-only):
- `acknowledge_finding` (POST /api/v1/security/findings/{id}/acknowledge)
- `revoke_acknowledgment` (DELETE /api/v1/security/findings/{id}/acknowledge)
- `list_scan_configs` (GET /api/v1/security/configs)

Closes #106
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`ArtifactSecurityViewModelTest` 13 (added acknowledge/revoke, incl. coVerify of request body + reload), `SecurityViewModelTest` 10 (added scan-configs), `CveTrackingViewModelTest` 10 (trimmed). All passing; `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes