### PR TITLE
feat(security): signing reads and quality read/operate actions

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityArtifactScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityArtifactScreen.kt
@@ -1,6 +1,7 @@
 package com.artifactkeeper.android.ui.screens.security
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -38,12 +39,23 @@ fun QualityArtifactScreen(
     val state by viewModel.artifactState.collectAsState()
     val parsedId = remember(artifactId) { runCatching { UUID.fromString(artifactId) }.getOrNull() }
     var issueToSuppress by remember { mutableStateOf<IssueResponse?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(parsedId) {
         parsedId?.let { viewModel.loadArtifactQuality(it) }
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    // Surface trigger/evaluate results without blanking the screen.
+    LaunchedEffect(state.message, state.error, state.health) {
+        val text = state.message ?: state.error?.takeIf { state.health != null }
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearArtifactMessage()
+        }
+    }
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+    Column(modifier = Modifier.fillMaxSize().padding(padding)) {
         TopAppBar(
             title = { Text("Artifact Quality") },
             navigationIcon = {
@@ -53,6 +65,16 @@ fun QualityArtifactScreen(
                         contentDescription = "Back",
                     )
                 }
+            },
+            actions = {
+                TextButton(
+                    onClick = { parsedId?.let { viewModel.triggerChecks(it) } },
+                    enabled = parsedId != null && !state.isMutating,
+                ) { Text("Run checks") }
+                TextButton(
+                    onClick = { parsedId?.let { viewModel.evaluateGate(it) } },
+                    enabled = parsedId != null && !state.isMutating,
+                ) { Text("Evaluate") }
             },
         )
 
@@ -70,7 +92,7 @@ fun QualityArtifactScreen(
                     CircularProgressIndicator()
                 }
             }
-            state.error != null -> {
+            state.error != null && state.health == null -> {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text(
@@ -92,6 +114,24 @@ fun QualityArtifactScreen(
                 ) {
                     state.health?.let { health ->
                         item { ArtifactHealthCard(health) }
+                    }
+
+                    state.gateEvaluation?.let { eval ->
+                        item { GateEvaluationCard(eval, onDismiss = { viewModel.clearGateEvaluation() }) }
+                    }
+
+                    if (state.checks.isNotEmpty()) {
+                        item {
+                            Text(
+                                text = "Checks (${state.checks.size})",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                        items(state.checks, key = { it.id }) { check ->
+                            QualityCheckCard(check, onClick = { viewModel.loadCheckDetail(check.id) })
+                        }
                     }
 
                     item {
@@ -124,6 +164,7 @@ fun QualityArtifactScreen(
             }
         }
     }
+    }
 
     issueToSuppress?.let { issue ->
         SuppressIssueDialog(
@@ -136,6 +177,126 @@ fun QualityArtifactScreen(
             onDismiss = { issueToSuppress = null },
         )
     }
+
+    state.selectedCheck?.let { check ->
+        CheckDetailDialog(check = check, onDismiss = { viewModel.clearSelectedCheck() })
+    }
+}
+
+@Composable
+private fun GateEvaluationCard(eval: com.artifactkeeper.client.models.GateEvaluationResponse, onDismiss: () -> Unit) {
+    val color = if (eval.passed) gradeColor("A") else gradeColor("F")
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Gate: ${eval.gateName}",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.weight(1f),
+                )
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(color.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = if (eval.passed) "Passed" else "Failed",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = color,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Action: ${eval.action.replaceFirstChar { it.uppercase() }}  -  Health ${eval.healthGrade} (${eval.healthScore})",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            eval.violations.forEach { v ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "${v.rule}: ${v.message} (expected ${v.expected}, actual ${v.actual})",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            TextButton(onClick = onDismiss) { Text("Dismiss") }
+        }
+    }
+}
+
+@Composable
+private fun QualityCheckCard(check: com.artifactkeeper.client.models.CheckResponse, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = check.checkType.replaceFirstChar { it.uppercase() },
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    text = "${check.issuesCount} issue${if (check.issuesCount != 1) "s" else ""}  -  ${check.status}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            check.score?.let { s ->
+                Text(
+                    text = "$s",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = when {
+                        s >= 80 -> gradeColor("A")
+                        s >= 60 -> gradeColor("C")
+                        else -> gradeColor("F")
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CheckDetailDialog(check: com.artifactkeeper.client.models.CheckResponse, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(check.checkType.replaceFirstChar { it.uppercase() } + " check") },
+        text = {
+            Column {
+                Text(
+                    text = "Status: ${check.status}",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                check.score?.let {
+                    Text("Score: $it", style = MaterialTheme.typography.bodyMedium)
+                }
+                Text(
+                    text = "Issues: ${check.issuesCount} (C ${check.criticalCount} / H ${check.highCount} / M ${check.mediumCount} / L ${check.lowCount})",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                check.errorMessage?.takeIf { it.isNotBlank() }?.let { err ->
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(text = err, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityHealthScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityHealthScreen.kt
@@ -1,6 +1,7 @@
 package com.artifactkeeper.android.ui.screens.security
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -42,6 +43,8 @@ fun QualityHealthScreen(
     viewModel: QualityViewModel = hiltViewModel(),
 ) {
     val state by viewModel.healthState.collectAsState()
+    val repoHealthState by viewModel.repoHealthState.collectAsState()
+    var showRepoHealth by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) { viewModel.loadHealth() }
 
@@ -83,7 +86,13 @@ fun QualityHealthScreen(
                             )
                         }
                         items(dashboard.repositories, key = { it.repositoryId }) { repo ->
-                            RepoHealthCard(repo)
+                            RepoHealthCard(
+                                repo = repo,
+                                onClick = {
+                                    viewModel.loadRepoHealth(repo.repositoryKey)
+                                    showRepoHealth = true
+                                },
+                            )
                         }
                     }
                 }
@@ -104,6 +113,70 @@ fun QualityHealthScreen(
             }
         }
     }
+
+    if (showRepoHealth) {
+        RepoHealthDetailDialog(
+            isLoading = repoHealthState.isLoading,
+            health = repoHealthState.health,
+            error = repoHealthState.error,
+            onDismiss = { showRepoHealth = false },
+        )
+    }
+}
+
+@Composable
+private fun RepoHealthDetailDialog(
+    isLoading: Boolean,
+    health: RepoHealthResponse?,
+    error: String?,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(health?.repositoryKey ?: "Repository health") },
+        text = {
+            when {
+                isLoading -> {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                error != null -> Text(text = error, color = MaterialTheme.colorScheme.error)
+                health != null -> {
+                    Column {
+                        Text(
+                            text = "Grade ${health.healthGrade} (${health.healthScore}/100)",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        Text(
+                            text = "${health.artifactsPassing} passing, ${health.artifactsFailing} failing of ${health.artifactsEvaluated}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        val subs = buildList {
+                            health.avgQualityScore?.let { add("Quality $it") }
+                            health.avgSecurityScore?.let { add("Security $it") }
+                            health.avgLicenseScore?.let { add("License $it") }
+                            health.avgMetadataScore?.let { add("Metadata $it") }
+                        }
+                        if (subs.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = subs.joinToString("  -  "),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+                else -> Text("No data")
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+    )
 }
 
 @Composable
@@ -168,9 +241,9 @@ private fun GradePill(label: String, count: Long, color: Color) {
 }
 
 @Composable
-private fun RepoHealthCard(repo: RepoHealthResponse) {
+private fun RepoHealthCard(repo: RepoHealthResponse, onClick: () -> Unit) {
     val color = gradeColor(repo.healthGrade)
-    Card(modifier = Modifier.fillMaxWidth()) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/QualityViewModel.kt
@@ -6,10 +6,13 @@ import com.artifactkeeper.android.data.api.ApiClient
 import com.artifactkeeper.android.data.api.unwrap
 import com.artifactkeeper.client.models.ArtifactHealthResponse
 import com.artifactkeeper.client.models.CheckResponse
+import com.artifactkeeper.client.models.GateEvaluationResponse
 import com.artifactkeeper.client.models.GateResponse
 import com.artifactkeeper.client.models.HealthDashboardResponse
 import com.artifactkeeper.client.models.IssueResponse
+import com.artifactkeeper.client.models.RepoHealthResponse
 import com.artifactkeeper.client.models.SuppressIssueRequest
+import com.artifactkeeper.client.models.TriggerChecksRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -39,8 +42,20 @@ data class QualityArtifactUiState(
     val health: ArtifactHealthResponse? = null,
     val checks: List<CheckResponse> = emptyList(),
     val issues: List<IssueResponse> = emptyList(),
+    val selectedCheck: CheckResponse? = null,
+    val gateEvaluation: GateEvaluationResponse? = null,
     val isLoading: Boolean = false,
     val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+)
+
+/**
+ * State for a single repository's health detail.
+ */
+data class RepoHealthDetailUiState(
+    val health: RepoHealthResponse? = null,
+    val isLoading: Boolean = false,
     val error: String? = null,
 )
 
@@ -54,6 +69,9 @@ class QualityViewModel @Inject constructor(
 
     private val _artifactState = MutableStateFlow(QualityArtifactUiState())
     val artifactState: StateFlow<QualityArtifactUiState> = _artifactState.asStateFlow()
+
+    private val _repoHealthState = MutableStateFlow(RepoHealthDetailUiState())
+    val repoHealthState: StateFlow<RepoHealthDetailUiState> = _repoHealthState.asStateFlow()
 
     /**
      * Load the portfolio health dashboard and the quality gates. Gates are
@@ -156,6 +174,80 @@ class QualityViewModel @Inject constructor(
             } catch (e: Exception) {
                 _artifactState.update {
                     it.copy(error = e.message ?: "Failed to unsuppress issue", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /** Load the full detail for a single check. */
+    fun loadCheckDetail(checkId: UUID) {
+        viewModelScope.launch {
+            try {
+                val check = apiClient.qualityApi.getCheck(checkId).unwrap()
+                _artifactState.update { it.copy(selectedCheck = check) }
+            } catch (e: Exception) {
+                _artifactState.update { it.copy(error = e.message ?: "Failed to load check") }
+            }
+        }
+    }
+
+    fun clearSelectedCheck() {
+        _artifactState.update { it.copy(selectedCheck = null) }
+    }
+
+    /** Queue quality checks for an artifact, then reload its quality view. */
+    fun triggerChecks(artifactId: UUID) {
+        viewModelScope.launch {
+            _artifactState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                val result = apiClient.qualityApi.triggerChecks(
+                    TriggerChecksRequest(artifactId = artifactId),
+                ).unwrap()
+                _artifactState.update {
+                    it.copy(isMutating = false, message = "${result.message} (${result.artifactsQueued} queued)")
+                }
+                loadArtifactQuality(artifactId)
+            } catch (e: Exception) {
+                _artifactState.update {
+                    it.copy(error = e.message ?: "Failed to trigger checks", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /** Evaluate the quality gates against an artifact and surface the result. */
+    fun evaluateGate(artifactId: UUID) {
+        viewModelScope.launch {
+            _artifactState.update { it.copy(isMutating = true, error = null) }
+            try {
+                val evaluation = apiClient.qualityApi.evaluateGate(artifactId).unwrap()
+                _artifactState.update { it.copy(gateEvaluation = evaluation, isMutating = false) }
+            } catch (e: Exception) {
+                _artifactState.update {
+                    it.copy(error = e.message ?: "Failed to evaluate gate", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun clearGateEvaluation() {
+        _artifactState.update { it.copy(gateEvaluation = null) }
+    }
+
+    fun clearArtifactMessage() {
+        _artifactState.update { it.copy(message = null, error = null) }
+    }
+
+    /** Load a single repository's health detail. */
+    fun loadRepoHealth(key: String) {
+        viewModelScope.launch {
+            _repoHealthState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val health = apiClient.qualityApi.getRepoHealth(key).unwrap()
+                _repoHealthState.update { it.copy(health = health, isLoading = false) }
+            } catch (e: Exception) {
+                _repoHealthState.update {
+                    it.copy(error = e.message ?: "Failed to load repository health", isLoading = false)
                 }
             }
         }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/RepoSecurityScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/RepoSecurityScreen.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.artifactkeeper.android.ui.theme.Critical
@@ -24,6 +26,7 @@ import com.artifactkeeper.client.models.DashboardResponse
 import com.artifactkeeper.client.models.ScanConfigResponse
 import com.artifactkeeper.client.models.ScanResponse
 import com.artifactkeeper.client.models.ScoreResponse
+import com.artifactkeeper.client.models.SigningConfigResponse
 
 private val GradeA = Color(0xFF52C41A)
 private val GradeB = Color(0xFF36CFC9)
@@ -120,6 +123,9 @@ fun RepoSecurityScreen(
                     }
                     state.config?.let { config ->
                         item { ScanConfigCard(config) }
+                    }
+                    state.signingConfig?.let { signing ->
+                        item { SigningConfigCard(signing, state.repoPublicKey) }
                     }
                     if (state.score == null && state.config == null) {
                         item {
@@ -306,6 +312,37 @@ private fun ScanConfigCard(config: ScanConfigResponse) {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+    }
+}
+
+@Composable
+private fun SigningConfigCard(config: SigningConfigResponse, publicKeyPem: String?) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Signing",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ConfigRow("Require signatures", config.requireSignatures)
+            ConfigRow("Sign packages", config.signPackages)
+            ConfigRow("Sign metadata", config.signMetadata)
+            publicKeyPem?.takeIf { it.isNotBlank() }?.let { pem ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Repository public key",
+                    style = MaterialTheme.typography.labelMedium,
+                )
+                Text(
+                    text = pem,
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 6,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/RepoSecurityViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/RepoSecurityViewModel.kt
@@ -8,6 +8,7 @@ import com.artifactkeeper.client.models.DashboardResponse
 import com.artifactkeeper.client.models.ScanConfigResponse
 import com.artifactkeeper.client.models.ScanResponse
 import com.artifactkeeper.client.models.ScoreResponse
+import com.artifactkeeper.client.models.SigningConfigResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,6 +25,8 @@ data class RepoSecurityUiState(
     val config: ScanConfigResponse? = null,
     val score: ScoreResponse? = null,
     val scans: List<ScanResponse> = emptyList(),
+    val signingConfig: SigningConfigResponse? = null,
+    val repoPublicKey: String? = null,
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val error: String? = null,
@@ -70,11 +73,31 @@ class RepoSecurityViewModel @Inject constructor(
                     // No scans available for this repository.
                 }
 
+                // Signing config and repo public key are optional reads keyed by
+                // the repository's UUID (available from the config or score).
+                val repoUuid = security.config?.repositoryId ?: security.score?.repositoryId
+                var signingConfig: SigningConfigResponse? = null
+                var repoPublicKey: String? = null
+                if (repoUuid != null) {
+                    try {
+                        signingConfig = apiClient.signingApi.getRepoSigningConfig(repoUuid).unwrap()
+                        repoPublicKey = try {
+                            apiClient.signingApi.getRepoPublicKey(repoUuid).unwrap()
+                        } catch (_: Exception) {
+                            null
+                        }
+                    } catch (_: Exception) {
+                        // No signing config bound to this repository.
+                    }
+                }
+
                 _uiState.update {
                     it.copy(
                         config = security.config,
                         score = security.score,
                         scans = scans,
+                        signingConfig = signingConfig,
+                        repoPublicKey = repoPublicKey,
                         isLoading = false,
                         isRefreshing = false,
                     )

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SigningKeysScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SigningKeysScreen.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Key
@@ -14,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -37,9 +40,11 @@ fun SigningKeysScreen(
     viewModel: SigningViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    val keyDetailState by viewModel.keyDetailState.collectAsState()
     var showCreateDialog by remember { mutableStateOf(false) }
     var keyToRevoke by remember { mutableStateOf<SigningKeyPublic?>(null) }
     var keyToDelete by remember { mutableStateOf<SigningKeyPublic?>(null) }
+    var showKeyDetail by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) { viewModel.loadKeys() }
@@ -100,6 +105,10 @@ fun SigningKeysScreen(
                             SigningKeyCard(
                                 key = key,
                                 isMutating = state.isMutating,
+                                onView = {
+                                    viewModel.loadKeyDetail(key.id)
+                                    showKeyDetail = true
+                                },
                                 onRotate = { viewModel.rotateKey(key.id) },
                                 onRevoke = { keyToRevoke = key },
                                 onDelete = { keyToDelete = key },
@@ -147,12 +156,24 @@ fun SigningKeysScreen(
             onDismiss = { keyToDelete = null },
         )
     }
+
+    if (showKeyDetail) {
+        KeyDetailDialog(
+            isLoading = keyDetailState.isLoading,
+            keyName = keyDetailState.key?.name,
+            fingerprint = keyDetailState.key?.fingerprint,
+            publicKeyPem = keyDetailState.publicKeyPem,
+            error = keyDetailState.error,
+            onDismiss = { showKeyDetail = false },
+        )
+    }
 }
 
 @Composable
 private fun SigningKeyCard(
     key: SigningKeyPublic,
     isMutating: Boolean,
+    onView: () -> Unit,
     onRotate: () -> Unit,
     onRevoke: () -> Unit,
     onDelete: () -> Unit,
@@ -203,6 +224,7 @@ private fun SigningKeyCard(
 
             Spacer(modifier = Modifier.height(8.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                TextButton(onClick = onView) { Text("View") }
                 TextButton(onClick = onRotate, enabled = !isMutating) { Text("Rotate") }
                 if (key.isActive) {
                     TextButton(onClick = onRevoke, enabled = !isMutating) { Text("Revoke") }
@@ -302,6 +324,65 @@ private fun ConfirmDialog(
         },
         dismissButton = {
             TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}
+
+@Composable
+private fun KeyDetailDialog(
+    isLoading: Boolean,
+    keyName: String?,
+    fingerprint: String?,
+    publicKeyPem: String?,
+    error: String?,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(keyName ?: "Signing key") },
+        text = {
+            when {
+                isLoading -> {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                error != null -> {
+                    Text(text = error, color = MaterialTheme.colorScheme.error)
+                }
+                else -> {
+                    Column {
+                        fingerprint?.takeIf { it.isNotBlank() }?.let { fp ->
+                            Text(
+                                text = "Fingerprint",
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                            Text(
+                                text = fp,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        Text(
+                            text = "Public key",
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                        Text(
+                            text = publicKeyPem ?: "Unavailable",
+                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 240.dp)
+                                .verticalScroll(rememberScrollState()),
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
         },
     )
 }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SigningViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/SigningViewModel.kt
@@ -27,6 +27,16 @@ data class SigningUiState(
     val message: String? = null,
 )
 
+/**
+ * State for a single signing key's detail, including its public key PEM.
+ */
+data class KeyDetailUiState(
+    val key: SigningKeyPublic? = null,
+    val publicKeyPem: String? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
 @HiltViewModel
 class SigningViewModel @Inject constructor(
     private val apiClient: ApiClient,
@@ -34,6 +44,33 @@ class SigningViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(SigningUiState())
     val uiState: StateFlow<SigningUiState> = _uiState.asStateFlow()
+
+    private val _keyDetailState = MutableStateFlow(KeyDetailUiState())
+    val keyDetailState: StateFlow<KeyDetailUiState> = _keyDetailState.asStateFlow()
+
+    /**
+     * Load a single key's metadata and its public key PEM for the detail view.
+     */
+    fun loadKeyDetail(keyId: UUID) {
+        viewModelScope.launch {
+            _keyDetailState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val key = apiClient.signingApi.getKey(keyId).unwrap()
+                val pem = try {
+                    apiClient.signingApi.getPublicKey(keyId).unwrap()
+                } catch (_: Exception) {
+                    key.publicKeyPem
+                }
+                _keyDetailState.update {
+                    it.copy(key = key, publicKeyPem = pem, isLoading = false)
+                }
+            } catch (e: Exception) {
+                _keyDetailState.update {
+                    it.copy(error = e.message ?: "Failed to load key detail", isLoading = false)
+                }
+            }
+        }
+    }
 
     fun loadKeys(refresh: Boolean = false) {
         viewModelScope.launch {

--- a/app/src/test/java/com/artifactkeeper/android/SecurityReadsViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/SecurityReadsViewModelTest.kt
@@ -1,0 +1,297 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.security.QualityViewModel
+import com.artifactkeeper.android.ui.screens.security.RepoSecurityViewModel
+import com.artifactkeeper.android.ui.screens.security.SigningViewModel
+import com.artifactkeeper.client.apis.QualityApi
+import com.artifactkeeper.client.apis.SecurityApi
+import com.artifactkeeper.client.apis.SigningApi
+import com.artifactkeeper.client.models.CheckResponse
+import com.artifactkeeper.client.models.GateEvaluationResponse
+import com.artifactkeeper.client.models.RepoHealthResponse
+import com.artifactkeeper.client.models.RepoSecurityResponse
+import com.artifactkeeper.client.models.ScanListResponse
+import com.artifactkeeper.client.models.ScoreResponse
+import com.artifactkeeper.client.models.SigningConfigResponse
+import com.artifactkeeper.client.models.SigningKeyPublic
+import com.artifactkeeper.client.models.TriggerChecksRequest
+import com.artifactkeeper.client.models.TriggerChecksResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SecurityReadsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockSigningApi = mockk<SigningApi>()
+    private val mockSecurityApi = mockk<SecurityApi>()
+    private val mockQualityApi = mockk<QualityApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { signingApi } returns mockSigningApi
+        every { securityApi } returns mockSecurityApi
+        every { qualityApi } returns mockQualityApi
+    }
+
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+    private val repoId = UUID.randomUUID()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun key(id: UUID) = SigningKeyPublic(
+        algorithm = "ed25519",
+        createdAt = now,
+        id = id,
+        isActive = true,
+        keyType = "gpg",
+        name = "release",
+        publicKeyPem = "PEM-IN-LIST",
+    )
+
+    private fun score() = ScoreResponse(
+        acknowledgedCount = 0,
+        calculatedAt = now,
+        criticalCount = 0,
+        grade = "A",
+        highCount = 0,
+        id = UUID.randomUUID(),
+        lowCount = 0,
+        mediumCount = 0,
+        repositoryId = repoId,
+        score = 95,
+        totalFindings = 0,
+    )
+
+    private fun signingConfig() = SigningConfigResponse(
+        repositoryId = repoId,
+        requireSignatures = true,
+        signMetadata = true,
+        signPackages = true,
+    )
+
+    private fun check(id: UUID) = CheckResponse(
+        artifactId = UUID.randomUUID(),
+        checkType = "metadata",
+        createdAt = now,
+        criticalCount = 0,
+        highCount = 1,
+        id = id,
+        infoCount = 0,
+        issuesCount = 1,
+        lowCount = 0,
+        mediumCount = 0,
+        repositoryId = repoId,
+        status = "completed",
+    )
+
+    private fun repoHealth(key: String) = RepoHealthResponse(
+        artifactsEvaluated = 5,
+        artifactsFailing = 1,
+        artifactsPassing = 4,
+        healthGrade = "B",
+        healthScore = 75,
+        repositoryId = repoId,
+        repositoryKey = key,
+    )
+
+    private fun gateEval(passed: Boolean) = GateEvaluationResponse(
+        action = "block",
+        componentScores = emptyMap<String, Any>(),
+        gateName = "Release Gate",
+        healthGrade = "B",
+        healthScore = 75,
+        passed = passed,
+        violations = emptyList(),
+    )
+
+    // =========================================================================
+    // SigningViewModel.loadKeyDetail (get_key + get_public_key)
+    // =========================================================================
+
+    @Test
+    fun `loadKeyDetail populates key and public key pem`() = runTest {
+        val keyId = UUID.randomUUID()
+        coEvery { mockSigningApi.getKey(keyId) } returns Response.success(key(keyId))
+        coEvery { mockSigningApi.getPublicKey(keyId) } returns Response.success("PEM-FETCHED")
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.loadKeyDetail(keyId)
+
+        val state = vm.keyDetailState.value
+        assertEquals(keyId, state.key?.id)
+        assertEquals("PEM-FETCHED", state.publicKeyPem)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadKeyDetail sets error when key fetch fails`() = runTest {
+        val keyId = UUID.randomUUID()
+        coEvery { mockSigningApi.getKey(keyId) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = SigningViewModel(mockApiClient)
+        vm.loadKeyDetail(keyId)
+
+        assertNotNull(vm.keyDetailState.value.error)
+        assertNull(vm.keyDetailState.value.key)
+    }
+
+    // =========================================================================
+    // RepoSecurityViewModel signing config (get_repo_signing_config + get_repo_public_key)
+    // =========================================================================
+
+    @Test
+    fun `loadRepoSecurity also loads signing config and repo public key`() = runTest {
+        coEvery { mockSecurityApi.getRepoSecurity("maven") } returns Response.success(
+            RepoSecurityResponse(config = null, score = score()),
+        )
+        coEvery { mockSecurityApi.listRepoScans("maven") } returns Response.success(
+            ScanListResponse(items = emptyList(), total = 0),
+        )
+        coEvery { mockSigningApi.getRepoSigningConfig(repoId) } returns Response.success(signingConfig())
+        coEvery { mockSigningApi.getRepoPublicKey(repoId) } returns Response.success("REPO-PEM")
+
+        val vm = RepoSecurityViewModel(mockApiClient)
+        vm.loadRepoSecurity("maven")
+
+        val state = vm.uiState.value
+        assertNotNull(state.signingConfig)
+        assertEquals("REPO-PEM", state.repoPublicKey)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadRepoSecurity tolerates missing signing config`() = runTest {
+        coEvery { mockSecurityApi.getRepoSecurity("maven") } returns Response.success(
+            RepoSecurityResponse(config = null, score = score()),
+        )
+        coEvery { mockSecurityApi.listRepoScans("maven") } returns Response.success(
+            ScanListResponse(items = emptyList(), total = 0),
+        )
+        coEvery { mockSigningApi.getRepoSigningConfig(repoId) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "none"))
+
+        val vm = RepoSecurityViewModel(mockApiClient)
+        vm.loadRepoSecurity("maven")
+
+        assertNull(vm.uiState.value.signingConfig)
+        assertNull(vm.uiState.value.error)
+    }
+
+    // =========================================================================
+    // QualityViewModel check detail (get_check)
+    // =========================================================================
+
+    @Test
+    fun `loadCheckDetail populates selected check`() = runTest {
+        val checkId = UUID.randomUUID()
+        coEvery { mockQualityApi.getCheck(checkId) } returns Response.success(check(checkId))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.loadCheckDetail(checkId)
+
+        assertEquals(checkId, vm.artifactState.value.selectedCheck?.id)
+    }
+
+    // =========================================================================
+    // QualityViewModel triggerChecks + evaluateGate (operate actions)
+    // =========================================================================
+
+    @Test
+    fun `triggerChecks posts request for the artifact and reloads`() = runTest {
+        val artifactId = UUID.randomUUID()
+        coEvery { mockQualityApi.triggerChecks(any()) } returns
+            Response.success(TriggerChecksResponse(artifactsQueued = 1, message = "queued"))
+        coEvery { mockQualityApi.getArtifactHealth(artifactId) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "pending"))
+        coEvery { mockQualityApi.listChecks(artifactId, null) } returns Response.success(emptyList())
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.triggerChecks(artifactId)
+
+        coVerify { mockQualityApi.triggerChecks(TriggerChecksRequest(artifactId = artifactId)) }
+        assertNotNull(vm.artifactState.value.message)
+        assertFalse(vm.artifactState.value.isMutating)
+    }
+
+    @Test
+    fun `evaluateGate populates gate evaluation`() = runTest {
+        val artifactId = UUID.randomUUID()
+        coEvery { mockQualityApi.evaluateGate(artifactId, null) } returns Response.success(gateEval(passed = true))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.evaluateGate(artifactId)
+
+        val eval = vm.artifactState.value.gateEvaluation
+        assertNotNull(eval)
+        assertTrue(eval!!.passed)
+        assertFalse(vm.artifactState.value.isMutating)
+    }
+
+    @Test
+    fun `evaluateGate sets error on failure`() = runTest {
+        val artifactId = UUID.randomUUID()
+        coEvery { mockQualityApi.evaluateGate(artifactId, null) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.evaluateGate(artifactId)
+
+        assertNotNull(vm.artifactState.value.error)
+        assertFalse(vm.artifactState.value.isMutating)
+    }
+
+    // =========================================================================
+    // QualityViewModel repo health (get_repo_health)
+    // =========================================================================
+
+    @Test
+    fun `loadRepoHealth populates repo health detail`() = runTest {
+        coEvery { mockQualityApi.getRepoHealth("npm") } returns Response.success(repoHealth("npm"))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.loadRepoHealth("npm")
+
+        assertEquals("npm", vm.repoHealthState.value.health?.repositoryKey)
+        assertFalse(vm.repoHealthState.value.isLoading)
+    }
+
+    @Test
+    fun `loadRepoHealth sets error on failure`() = runTest {
+        coEvery { mockQualityApi.getRepoHealth("npm") } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = QualityViewModel(mockApiClient)
+        vm.loadRepoHealth("npm")
+
+        assertNotNull(vm.repoHealthState.value.error)
+    }
+}


### PR DESCRIPTION
## Summary
Final in-scope Security UI mop-up: surfaces the remaining signing reads and quality reads/operate actions that had SDK coverage but no UI.

- Signing key cards get a **View** action opening a key detail dialog showing the public key PEM (`get_key` + `get_public_key`).
- The repository security screen (`RepoSecurityScreen`) gets a **Signing** section showing the repo signing config and repo public key (`get_repo_signing_config` + `get_repo_public_key`).
- The artifact quality screen (`QualityArtifactScreen`) gets tappable **check** cards opening a check detail (`get_check`), plus **Run checks** (`trigger_checks`) and **Evaluate** (`evaluate_gate`) toolbar actions with a gate-evaluation result card. Mutation results surface via snackbar; the screen stays visible on transient failure.
- Quality dashboard (`QualityHealthScreen`) repo health cards become tappable, opening a repo health detail (`get_repo_health`).

All new reads are optional/non-destructive. Rebased onto current main (after #107). No nav-host changes; no parity-matrix edits (maintained centrally).

Operations given a UI surface (previously SDK-only):
- `get_key`, `get_public_key`, `get_repo_signing_config`, `get_repo_public_key`
- `get_check`, `get_repo_health`, `evaluate_gate`, `trigger_checks`

Deferred (admin authoring, not built; for an Administration/authoring pass or N/A): `create_gate`, `update_gate`, `delete_gate`, `update_repo_signing_config`.

Closes #108
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`SecurityReadsViewModelTest`: 10 tests across SigningViewModel / RepoSecurityViewModel / QualityViewModel, all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes