### PR TITLE
feat(integration): webhook detail, deliveries, redeliver, rotate-secret

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -47,6 +47,7 @@ import com.artifactkeeper.android.ui.screens.builds.BuildDetailScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildsScreen
 import com.artifactkeeper.android.ui.screens.integration.PeersScreen
 import com.artifactkeeper.android.ui.screens.integration.ReplicationScreen
+import com.artifactkeeper.android.ui.screens.integration.WebhookDetailScreen
 import com.artifactkeeper.android.ui.screens.integration.WebhooksScreen
 import com.artifactkeeper.android.ui.screens.operations.AnalyticsScreen
 import com.artifactkeeper.android.ui.screens.operations.MonitoringScreen
@@ -580,18 +581,42 @@ private fun SectionWithTabs(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable () -> Unit) {
-    SectionWithTabs(
-        title = "Integration",
-        subTabs = listOf("Peers", "Replication", "Webhooks"),
-        isCompact = isCompact,
-        accountActions = accountActions,
-    ) { selectedTab ->
-        when (selectedTab) {
-            0 -> PeersScreen()
-            1 -> ReplicationScreen()
-            2 -> WebhooksScreen()
+    val subTabs = listOf("Peers", "Replication", "Webhooks")
+    var selectedTab by remember { mutableIntStateOf(0) }
+    var selectedWebhookId by remember { mutableStateOf<String?>(null) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (selectedWebhookId != null) {
+            WebhookDetailScreen(
+                webhookId = selectedWebhookId!!,
+                onBack = { selectedWebhookId = null },
+            )
+        } else {
+            TopAppBar(
+                title = { Text("Integration") },
+                navigationIcon = { AppLogo() },
+                actions = { accountActions() },
+            )
+            ScrollableTabRow(
+                selectedTabIndex = selectedTab,
+                edgePadding = if (isCompact) 4.dp else 16.dp,
+            ) {
+                subTabs.forEachIndexed { index, title ->
+                    Tab(
+                        selected = selectedTab == index,
+                        onClick = { selectedTab = index },
+                        text = { Text(title, maxLines = 1) },
+                    )
+                }
+            }
+            when (selectedTab) {
+                0 -> PeersScreen()
+                1 -> ReplicationScreen()
+                2 -> WebhooksScreen(onWebhookClick = { selectedWebhookId = it })
+            }
         }
     }
 }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/WebhookDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/WebhookDetailScreen.kt
@@ -1,0 +1,297 @@
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.DeliveryResponse
+import com.artifactkeeper.client.models.WebhookResponse
+import java.util.UUID
+
+private val SuccessColor = Color(0xFF52C41A)
+private val FailureColor = Color(0xFFF5222D)
+
+/**
+ * Detail for a single webhook: its configuration, a Rotate secret action, and
+ * the recent delivery attempts (each re-sendable).
+ */
+@Composable
+fun WebhookDetailScreen(
+    webhookId: String,
+    onBack: () -> Unit,
+    viewModel: WebhookDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val parsedId = remember(webhookId) { runCatching { UUID.fromString(webhookId) }.getOrNull() }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(parsedId) {
+        parsedId?.let { viewModel.load(it) }
+    }
+
+    LaunchedEffect(state.message, state.error, state.webhook) {
+        val text = state.message ?: state.error?.takeIf { state.webhook != null }
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearMessage()
+        }
+    }
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TopAppBar(
+                title = { Text("Webhook") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = { parsedId?.let { viewModel.rotateSecret(it) } },
+                        enabled = parsedId != null && !state.isMutating,
+                    ) { Text("Rotate secret") }
+                },
+            )
+
+            when {
+                parsedId == null -> CenteredText("Invalid webhook id")
+                state.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.error != null && state.webhook == null -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = state.error ?: "Unknown error",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { viewModel.load(parsedId) }) { Text("Retry") }
+                        }
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        state.webhook?.let { webhook ->
+                            item { WebhookConfigCard(webhook) }
+                        }
+
+                        item {
+                            Text(
+                                text = "Deliveries (${state.deliveries.size})",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                        if (state.deliveries.isEmpty()) {
+                            item {
+                                Text(
+                                    text = "No deliveries recorded",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        } else {
+                            items(state.deliveries, key = { it.id }) { delivery ->
+                                DeliveryCard(
+                                    delivery = delivery,
+                                    isMutating = state.isMutating,
+                                    onRedeliver = {
+                                        parsedId?.let { viewModel.redeliver(it, delivery.id) }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    state.newSecret?.let { secret ->
+        AlertDialog(
+            onDismissRequest = { viewModel.clearNewSecret() },
+            title = { Text("New webhook secret") },
+            text = {
+                Column {
+                    Text(
+                        text = "Copy this secret now. It will not be shown again.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = secret,
+                        style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.clearNewSecret() }) { Text("Done") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun WebhookConfigCard(webhook: WebhookResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = webhook.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                val color = if (webhook.isEnabled) SuccessColor else MaterialTheme.colorScheme.onSurfaceVariant
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(color.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = if (webhook.isEnabled) "Enabled" else "Disabled",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = color,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = webhook.url,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            webhook.lastTriggeredAt?.let { ts ->
+                Text(
+                    text = "Last triggered ${ts.toLocalDate()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                webhook.events.forEach { event ->
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(MaterialTheme.colorScheme.secondaryContainer)
+                            .padding(horizontal = 8.dp, vertical = 4.dp),
+                    ) {
+                        Text(
+                            text = event.replace("_", " "),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeliveryCard(
+    delivery: DeliveryResponse,
+    isMutating: Boolean,
+    onRedeliver: () -> Unit,
+) {
+    val color = if (delivery.success) SuccessColor else FailureColor
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = delivery.event.replace("_", " "),
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(color.copy(alpha = 0.15f))
+                        .padding(horizontal = 10.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = delivery.responseStatus?.toString() ?: if (delivery.success) "OK" else "Failed",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = color,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "${delivery.attempts} attempt${if (delivery.attempts != 1) "s" else ""}  -  ${delivery.createdAt.toLocalDate()}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            delivery.responseBody?.takeIf { it.isNotBlank() }?.let { body ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = body,
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
+                TextButton(onClick = onRedeliver, enabled = !isMutating) { Text("Redeliver") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CenteredText(text: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/WebhookDetailViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/WebhookDetailViewModel.kt
@@ -1,0 +1,107 @@
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.DeliveryResponse
+import com.artifactkeeper.client.models.WebhookResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for a single webhook's detail: its configuration plus recent delivery
+ * attempts, and the secret produced by a rotation (shown once).
+ */
+data class WebhookDetailUiState(
+    val webhook: WebhookResponse? = null,
+    val deliveries: List<DeliveryResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+    val newSecret: String? = null,
+)
+
+@HiltViewModel
+class WebhookDetailViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(WebhookDetailUiState())
+    val uiState: StateFlow<WebhookDetailUiState> = _uiState.asStateFlow()
+
+    /**
+     * Load the webhook configuration and its recent deliveries. The delivery
+     * list is optional: an endpoint with no history (or that does not expose
+     * deliveries) should still render the webhook config.
+     */
+    fun load(webhookId: UUID) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val webhook = apiClient.webhooksApi.getWebhook(webhookId).unwrap()
+
+                var deliveries: List<DeliveryResponse> = emptyList()
+                try {
+                    deliveries = apiClient.webhooksApi.listDeliveries(webhookId).unwrap().items
+                } catch (_: Exception) {
+                    // No delivery history available.
+                }
+
+                _uiState.update {
+                    it.copy(webhook = webhook, deliveries = deliveries, isLoading = false)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to load webhook", isLoading = false)
+                }
+            }
+        }
+    }
+
+    /** Re-send a past delivery, then refresh the delivery list. */
+    fun redeliver(webhookId: UUID, deliveryId: UUID) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.webhooksApi.redeliver(webhookId, deliveryId).unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Delivery re-sent") }
+                load(webhookId)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to redeliver", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /** Rotate the signing secret and surface the new value once. */
+    fun rotateSecret(webhookId: UUID) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                val rotated = apiClient.webhooksApi.rotateWebhookSecret(webhookId).unwrap()
+                _uiState.update { it.copy(isMutating = false, newSecret = rotated.secret) }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to rotate secret", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun clearNewSecret() {
+        _uiState.update { it.copy(newSecret = null) }
+    }
+
+    fun clearMessage() {
+        _uiState.update { it.copy(message = null, error = null) }
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/WebhooksScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/WebhooksScreen.kt
@@ -3,6 +3,7 @@
 package com.artifactkeeper.android.ui.screens.integration
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -39,7 +40,7 @@ private val ALL_EVENTS = listOf(
 )
 
 @Composable
-fun WebhooksScreen() {
+fun WebhooksScreen(onWebhookClick: (String) -> Unit = {}) {
     var webhooks by remember { mutableStateOf<List<Webhook>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
     var isRefreshing by remember { mutableStateOf(false) }
@@ -125,6 +126,7 @@ fun WebhooksScreen() {
                         items(webhooks, key = { it.id }) { webhook ->
                             WebhookCard(
                                 webhook = webhook,
+                                onClick = { onWebhookClick(webhook.id.toString()) },
                                 onToggle = { enabled ->
                                     coroutineScope.launch {
                                         try {
@@ -253,11 +255,12 @@ fun WebhooksScreen() {
 @Composable
 private fun WebhookCard(
     webhook: Webhook,
+    onClick: () -> Unit,
     onToggle: (Boolean) -> Unit,
     onTest: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/security/CveTrackingViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/security/CveTrackingViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.artifactkeeper.android.data.api.ApiClient
 import com.artifactkeeper.android.data.api.unwrap
-import com.artifactkeeper.client.models.AcknowledgeRequest
 import com.artifactkeeper.client.models.CveHistoryEntry
 import com.artifactkeeper.client.models.UpdateCveStatusRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -104,31 +103,6 @@ class CveTrackingViewModel @Inject constructor(
                 _cveDetailState.update {
                     it.copy(error = e.message ?: "Failed to update CVE status", isUpdating = false)
                 }
-            }
-        }
-    }
-
-    fun acknowledgeFinding(findingId: UUID, reason: String) {
-        viewModelScope.launch {
-            try {
-                apiClient.securityApi.acknowledgeFinding(
-                    findingId,
-                    AcknowledgeRequest(reason = reason),
-                ).unwrap()
-                _uiState.update { it.copy(message = "Finding acknowledged") }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(error = e.message ?: "Failed to acknowledge finding") }
-            }
-        }
-    }
-
-    fun revokeAcknowledgment(findingId: UUID) {
-        viewModelScope.launch {
-            try {
-                apiClient.securityApi.revokeAcknowledgment(findingId).unwrap()
-                _uiState.update { it.copy(message = "Acknowledgment revoked") }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(error = e.message ?: "Failed to revoke acknowledgment") }
             }
         }
     }

--- a/app/src/test/java/com/artifactkeeper/android/CveTrackingViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/CveTrackingViewModelTest.kt
@@ -7,7 +7,6 @@ import com.artifactkeeper.android.ui.screens.security.CveTrackingViewModel
 import com.artifactkeeper.client.apis.SbomApi
 import com.artifactkeeper.client.apis.SecurityApi
 import com.artifactkeeper.client.models.CveHistoryEntry
-import com.artifactkeeper.client.models.FindingResponse
 import com.artifactkeeper.client.models.UpdateCveStatusRequest
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -71,16 +70,6 @@ class CveTrackingViewModelTest {
         updatedAt = now,
         cvssScore = score,
         severity = severity,
-    )
-
-    private fun finding() = FindingResponse(
-        artifactId = artifactId,
-        createdAt = now,
-        id = UUID.randomUUID(),
-        isAcknowledged = false,
-        scanResultId = UUID.randomUUID(),
-        severity = "high",
-        title = "Some vuln",
     )
 
     // =========================================================================
@@ -194,35 +183,6 @@ class CveTrackingViewModelTest {
 
         assertNotNull(vm.cveDetailState.value.error)
         assertFalse(vm.cveDetailState.value.isUpdating)
-    }
-
-    // =========================================================================
-    // acknowledgeFinding / revokeAcknowledgment
-    // =========================================================================
-
-    @Test
-    fun `acknowledgeFinding calls api with reason`() = runTest {
-        val findingId = UUID.randomUUID()
-        coEvery { mockSecurityApi.acknowledgeFinding(findingId, any()) } returns
-            Response.success(finding())
-
-        val vm = CveTrackingViewModel(mockApiClient)
-        vm.acknowledgeFinding(findingId, "accepted risk")
-
-        coVerify { mockSecurityApi.acknowledgeFinding(findingId, any()) }
-        assertNull(vm.uiState.value.error)
-    }
-
-    @Test
-    fun `revokeAcknowledgment calls api`() = runTest {
-        val findingId = UUID.randomUUID()
-        coEvery { mockSecurityApi.revokeAcknowledgment(findingId) } returns
-            Response.success(finding())
-
-        val vm = CveTrackingViewModel(mockApiClient)
-        vm.revokeAcknowledgment(findingId)
-
-        coVerify { mockSecurityApi.revokeAcknowledgment(findingId) }
     }
 
     @Test

--- a/app/src/test/java/com/artifactkeeper/android/WebhookDetailViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/WebhookDetailViewModelTest.kt
@@ -1,0 +1,197 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.integration.WebhookDetailUiState
+import com.artifactkeeper.android.ui.screens.integration.WebhookDetailViewModel
+import com.artifactkeeper.client.apis.WebhooksApi
+import com.artifactkeeper.client.models.DeliveryListResponse
+import com.artifactkeeper.client.models.DeliveryResponse
+import com.artifactkeeper.client.models.PayloadTemplate
+import com.artifactkeeper.client.models.RotateWebhookSecretResponse
+import com.artifactkeeper.client.models.WebhookResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WebhookDetailViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockWebhooksApi = mockk<WebhooksApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { webhooksApi } returns mockWebhooksApi
+    }
+
+    private val webhookId = UUID.randomUUID()
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun webhook() = WebhookResponse(
+        createdAt = now,
+        eventSchemaVersion = "v1",
+        events = listOf("artifact_uploaded"),
+        id = webhookId,
+        isEnabled = true,
+        name = "ci-hook",
+        payloadTemplate = PayloadTemplate.generic,
+        url = "https://example.test/hook",
+    )
+
+    private fun delivery(success: Boolean, id: UUID = UUID.randomUUID()) = DeliveryResponse(
+        attempts = 1,
+        createdAt = now,
+        event = "artifact_uploaded",
+        id = id,
+        payload = emptyMap<String, Any>(),
+        success = success,
+        webhookId = webhookId,
+        responseStatus = if (success) 200 else 500,
+    )
+
+    @Test
+    fun `initial state is empty`() {
+        val state = WebhookDetailUiState()
+        assertNull(state.webhook)
+        assertTrue(state.deliveries.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertNull(state.newSecret)
+    }
+
+    @Test
+    fun `load populates webhook and deliveries`() = runTest {
+        coEvery { mockWebhooksApi.getWebhook(webhookId) } returns Response.success(webhook())
+        coEvery { mockWebhooksApi.listDeliveries(webhookId, null, null, null) } returns Response.success(
+            DeliveryListResponse(items = listOf(delivery(true), delivery(false)), total = 2),
+        )
+
+        val vm = WebhookDetailViewModel(mockApiClient)
+        vm.load(webhookId)
+
+        val state = vm.uiState.value
+        assertEquals(webhookId, state.webhook?.id)
+        assertEquals(2, state.deliveries.size)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `load tolerates missing deliveries`() = runTest {
+        coEvery { mockWebhooksApi.getWebhook(webhookId) } returns Response.success(webhook())
+        coEvery { mockWebhooksApi.listDeliveries(webhookId, null, null, null) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "none"))
+
+        val vm = WebhookDetailViewModel(mockApiClient)
+        vm.load(webhookId)
+
+        assertNotNull(vm.uiState.value.webhook)
+        assertTrue(vm.uiState.value.deliveries.isEmpty())
+        assertNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `load sets error when webhook fetch fails`() = runTest {
+        coEvery { mockWebhooksApi.getWebhook(webhookId) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = WebhookDetailViewModel(mockApiClient)
+        vm.load(webhookId)
+
+        assertNotNull(vm.uiState.value.error)
+        assertNull(vm.uiState.value.webhook)
+    }
+
+    @Test
+    fun `redeliver calls api and reloads deliveries`() = runTest {
+        val deliveryId = UUID.randomUUID()
+        coEvery { mockWebhooksApi.getWebhook(webhookId) } returns Response.success(webhook())
+        coEvery { mockWebhooksApi.listDeliveries(webhookId, null, null, null) } returns Response.success(
+            DeliveryListResponse(items = listOf(delivery(true, deliveryId)), total = 1),
+        )
+        coEvery { mockWebhooksApi.redeliver(webhookId, deliveryId) } returns Response.success(delivery(true, deliveryId))
+
+        val vm = WebhookDetailViewModel(mockApiClient)
+        vm.load(webhookId)
+        vm.redeliver(webhookId, deliveryId)
+
+        coVerify { mockWebhooksApi.redeliver(webhookId, deliveryId) }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `redeliver sets error on failure`() = runTest {
+        val deliveryId = UUID.randomUUID()
+        coEvery { mockWebhooksApi.redeliver(webhookId, deliveryId) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+        coEvery { mockWebhooksApi.getWebhook(webhookId) } returns Response.success(webhook())
+        coEvery { mockWebhooksApi.listDeliveries(webhookId, null, null, null) } returns Response.success(
+            DeliveryListResponse(items = emptyList(), total = 0),
+        )
+
+        val vm = WebhookDetailViewModel(mockApiClient)
+        vm.redeliver(webhookId, deliveryId)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `rotateSecret surfaces the new secret`() = runTest {
+        coEvery { mockWebhooksApi.getWebhook(webhookId) } returns Response.success(webhook())
+        coEvery { mockWebhooksApi.listDeliveries(webhookId, null, null, null) } returns Response.success(
+            DeliveryListResponse(items = emptyList(), total = 0),
+        )
+        coEvery { mockWebhooksApi.rotateWebhookSecret(webhookId) } returns Response.success(
+            RotateWebhookSecretResponse(
+                id = webhookId,
+                previousSecretExpiresAt = now,
+                secret = "new-secret-value",
+                secretDigest = "digest",
+            ),
+        )
+
+        val vm = WebhookDetailViewModel(mockApiClient)
+        vm.rotateSecret(webhookId)
+
+        assertEquals("new-secret-value", vm.uiState.value.newSecret)
+        coVerify { mockWebhooksApi.rotateWebhookSecret(webhookId) }
+    }
+
+    @Test
+    fun `rotateSecret sets error on failure`() = runTest {
+        coEvery { mockWebhooksApi.rotateWebhookSecret(webhookId) } returns
+            Response.error(409, okhttp3.ResponseBody.create(null, "conflict"))
+
+        val vm = WebhookDetailViewModel(mockApiClient)
+        vm.rotateSecret(webhookId)
+
+        assertNotNull(vm.uiState.value.error)
+        assertNull(vm.uiState.value.newSecret)
+    }
+}


### PR DESCRIPTION
## Summary
First Android Integration cluster: adds a webhook detail view to the Integration > Webhooks tab.

- Tapping a webhook card opens `WebhookDetailScreen`: the webhook config (name, URL, enabled state, event chips, last triggered) plus its recent delivery attempts.
- Each delivery shows event, response status, attempt count, and (when present) the response body; each can be re-sent via **Redeliver**.
- A **Rotate secret** toolbar action rotates the signing secret and shows the new secret once in a dialog (copy-now warning).
- `WebhookDetailViewModel` is Hilt-injected with loading/error/message states. Deliveries are optional (non-destructive) so a webhook with no history still renders; mutation results surface via snackbar without blanking the screen.

Operations wired (previously missing):
- `get_webhook` (GET /api/v1/webhooks/{id})
- `list_deliveries` (GET /api/v1/webhooks/{id}/deliveries)
- `redeliver` (POST /api/v1/webhooks/{id}/deliveries/{delivery_id}/redeliver)
- `rotate_webhook_secret` (POST /api/v1/webhooks/{id}/rotate-secret)

Incidental cleanup: removes the now-dead `acknowledgeFinding` / `revokeAcknowledgment` methods (and 2 tests) left in `CveTrackingViewModel` from the Security CVE wave; the real acknowledge/revoke UI lives in `ArtifactSecurityViewModel`.

No parity-matrix edits (maintained centrally).

Closes #110
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`WebhookDetailViewModelTest`: 8 tests, all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes