### PR TITLE
feat(integration): plugins management and plugin detail

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -12,6 +12,7 @@ import com.artifactkeeper.client.apis.HealthApi
 import com.artifactkeeper.client.apis.MonitoringApi
 import com.artifactkeeper.client.apis.PackagesApi
 import com.artifactkeeper.client.apis.PeersApi
+import com.artifactkeeper.client.apis.PluginsApi
 import com.artifactkeeper.client.apis.PromotionApi
 import com.artifactkeeper.client.apis.QualityApi
 import com.artifactkeeper.client.apis.RepositoriesApi
@@ -62,6 +63,7 @@ object ApiClient {
     lateinit var usersApi: UsersApi private set
     lateinit var groupsApi: GroupsApi private set
     lateinit var peersApi: PeersApi private set
+    lateinit var pluginsApi: PluginsApi private set
     lateinit var webhooksApi: WebhooksApi private set
     lateinit var analyticsApi: AnalyticsApi private set
     lateinit var monitoringApi: MonitoringApi private set
@@ -129,6 +131,7 @@ object ApiClient {
         usersApi = client.createService(UsersApi::class.java)
         groupsApi = client.createService(GroupsApi::class.java)
         peersApi = client.createService(PeersApi::class.java)
+        pluginsApi = client.createService(PluginsApi::class.java)
         webhooksApi = client.createService(WebhooksApi::class.java)
         analyticsApi = client.createService(AnalyticsApi::class.java)
         monitoringApi = client.createService(MonitoringApi::class.java)

--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -47,6 +47,8 @@ import com.artifactkeeper.android.ui.screens.builds.BuildDetailScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildsScreen
 import com.artifactkeeper.android.ui.screens.integration.PeersScreen
 import com.artifactkeeper.android.ui.screens.integration.ReplicationScreen
+import com.artifactkeeper.android.ui.screens.integration.PluginDetailScreen
+import com.artifactkeeper.android.ui.screens.integration.PluginsScreen
 import com.artifactkeeper.android.ui.screens.integration.WebhookDetailScreen
 import com.artifactkeeper.android.ui.screens.integration.WebhooksScreen
 import com.artifactkeeper.android.ui.screens.operations.AnalyticsScreen
@@ -584,15 +586,21 @@ private fun SectionWithTabs(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable () -> Unit) {
-    val subTabs = listOf("Peers", "Replication", "Webhooks")
+    val subTabs = listOf("Peers", "Replication", "Webhooks", "Plugins")
     var selectedTab by remember { mutableIntStateOf(0) }
     var selectedWebhookId by remember { mutableStateOf<String?>(null) }
+    var selectedPluginId by remember { mutableStateOf<String?>(null) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         if (selectedWebhookId != null) {
             WebhookDetailScreen(
                 webhookId = selectedWebhookId!!,
                 onBack = { selectedWebhookId = null },
+            )
+        } else if (selectedPluginId != null) {
+            PluginDetailScreen(
+                pluginId = selectedPluginId!!,
+                onBack = { selectedPluginId = null },
             )
         } else {
             TopAppBar(
@@ -616,6 +624,7 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
                 0 -> PeersScreen()
                 1 -> ReplicationScreen()
                 2 -> WebhooksScreen(onWebhookClick = { selectedWebhookId = it })
+                3 -> PluginsScreen(onPluginClick = { selectedPluginId = it })
             }
         }
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PluginDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PluginDetailScreen.kt
@@ -1,0 +1,154 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.PluginResponse
+import java.util.UUID
+
+/**
+ * Detail for a single plugin. Loads via getPlugin(id) on entry.
+ */
+@Composable
+fun PluginDetailScreen(
+    pluginId: String,
+    onBack: () -> Unit,
+    viewModel: PluginsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.detailState.collectAsState()
+    val parsedId = remember(pluginId) { runCatching { UUID.fromString(pluginId) }.getOrNull() }
+
+    LaunchedEffect(parsedId) {
+        parsedId?.let { viewModel.loadPluginDetail(it) }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text(state.plugin?.displayName ?: "Plugin") },
+            navigationIcon = {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                    )
+                }
+            },
+        )
+
+        when {
+            parsedId == null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = "Invalid plugin id",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.error != null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.loadPluginDetail(parsedId) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            else -> {
+                state.plugin?.let { plugin ->
+                    PluginDetailContent(plugin)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PluginDetailContent(plugin: PluginResponse) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = plugin.displayName,
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                    StatusBadge(plugin.status)
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "${plugin.name}  -  ${plugin.pluginType}  -  v${plugin.version}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                plugin.description?.takeIf { it.isNotBlank() }?.let { desc ->
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(text = desc, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
+
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = "Details",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                DetailRow("Installed", plugin.installedAt.toLocalDate().toString())
+                plugin.enabledAt?.let { DetailRow("Enabled", it.toLocalDate().toString()) }
+                plugin.author?.takeIf { it.isNotBlank() }?.let { DetailRow("Author", it) }
+                plugin.homepage?.takeIf { it.isNotBlank() }?.let { DetailRow("Homepage", it) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodySmall)
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PluginsScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PluginsScreen.kt
@@ -1,0 +1,283 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.PluginResponse
+
+private val EnabledColor = Color(0xFF52C41A)
+private val DisabledColor = Color(0xFFFAAD14)
+private val ErrorColor = Color(0xFFF5222D)
+
+private fun statusColor(status: String): Color = when (status.lowercase()) {
+    "enabled", "active", "running" -> EnabledColor
+    "disabled", "inactive", "stopped" -> DisabledColor
+    "error", "failed" -> ErrorColor
+    else -> DisabledColor
+}
+
+/**
+ * Plugins management: lists installed plugins with enable/disable/reload/
+ * uninstall actions and an install-from-git flow. Tapping a plugin opens its
+ * detail.
+ */
+@Composable
+fun PluginsScreen(
+    onPluginClick: (String) -> Unit = {},
+    viewModel: PluginsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showInstallDialog by remember { mutableStateOf(false) }
+    var pluginToUninstall by remember { mutableStateOf<PluginResponse?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) { viewModel.loadPlugins() }
+
+    LaunchedEffect(state.message, state.error) {
+        val text = state.message ?: state.error
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearMessages()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showInstallDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Install plugin from Git")
+            }
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.error != null && state.plugins.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = state.error ?: "Unknown error",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { viewModel.loadPlugins(refresh = true) }) {
+                                Text("Retry")
+                            }
+                        }
+                    }
+                }
+                state.plugins.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "No plugins installed. Use + to install from Git.",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(state.plugins, key = { it.id }) { plugin ->
+                            PluginCard(
+                                plugin = plugin,
+                                isMutating = state.isMutating,
+                                onClick = { onPluginClick(plugin.id.toString()) },
+                                onEnable = { viewModel.enablePlugin(plugin.id) },
+                                onDisable = { viewModel.disablePlugin(plugin.id) },
+                                onReload = { viewModel.reloadPlugin(plugin.id) },
+                                onUninstall = { pluginToUninstall = plugin },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showInstallDialog) {
+        InstallFromGitDialog(
+            isMutating = state.isMutating,
+            onDismiss = { showInstallDialog = false },
+            onConfirm = { url, ref ->
+                viewModel.installFromGit(url, ref)
+                showInstallDialog = false
+            },
+        )
+    }
+
+    pluginToUninstall?.let { plugin ->
+        AlertDialog(
+            onDismissRequest = { pluginToUninstall = null },
+            title = { Text("Uninstall plugin") },
+            text = { Text("Uninstall \"${plugin.displayName}\"? This cannot be undone.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.uninstallPlugin(plugin.id)
+                        pluginToUninstall = null
+                    },
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                ) { Text("Uninstall") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pluginToUninstall = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun PluginCard(
+    plugin: PluginResponse,
+    isMutating: Boolean,
+    onClick: () -> Unit,
+    onEnable: () -> Unit,
+    onDisable: () -> Unit,
+    onReload: () -> Unit,
+    onUninstall: () -> Unit,
+) {
+    val enabled = plugin.status.equals("enabled", ignoreCase = true) ||
+        plugin.status.equals("active", ignoreCase = true)
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Extension,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = plugin.displayName,
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = "${plugin.pluginType}  -  v${plugin.version}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                StatusBadge(plugin.status)
+                Icon(
+                    imageVector = Icons.Default.ChevronRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                if (enabled) {
+                    TextButton(onClick = onDisable, enabled = !isMutating) { Text("Disable") }
+                } else {
+                    TextButton(onClick = onEnable, enabled = !isMutating) { Text("Enable") }
+                }
+                TextButton(onClick = onReload, enabled = !isMutating) { Text("Reload") }
+                TextButton(
+                    onClick = onUninstall,
+                    enabled = !isMutating,
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+                ) { Text("Uninstall") }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun StatusBadge(status: String) {
+    val color = statusColor(status)
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = status.replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+private fun InstallFromGitDialog(
+    isMutating: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (url: String, ref: String?) -> Unit,
+) {
+    var url by remember { mutableStateOf("") }
+    var ref by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Install plugin from Git") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = url,
+                    onValueChange = { url = it },
+                    label = { Text("Git URL") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = ref,
+                    onValueChange = { ref = it },
+                    label = { Text("Ref (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(url.trim(), ref.trim().ifBlank { null }) },
+                enabled = !isMutating && url.isNotBlank(),
+            ) { Text("Install") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PluginsViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PluginsViewModel.kt
@@ -1,0 +1,140 @@
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.InstallFromGitRequest
+import com.artifactkeeper.client.models.PluginResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for the plugins list.
+ */
+data class PluginsUiState(
+    val plugins: List<PluginResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+)
+
+/**
+ * State for a single plugin's detail.
+ */
+data class PluginDetailUiState(
+    val plugin: PluginResponse? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+@HiltViewModel
+class PluginsViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PluginsUiState())
+    val uiState: StateFlow<PluginsUiState> = _uiState.asStateFlow()
+
+    private val _detailState = MutableStateFlow(PluginDetailUiState())
+    val detailState: StateFlow<PluginDetailUiState> = _detailState.asStateFlow()
+
+    fun loadPlugins(refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val plugins = apiClient.pluginsApi.listPlugins(null, null).unwrap().items
+                    .sortedBy { it.displayName.lowercase() }
+                _uiState.update {
+                    it.copy(plugins = plugins, isLoading = false, isRefreshing = false)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load plugins",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /** Load a single plugin's detail. Always hits getPlugin(id). */
+    fun loadPluginDetail(id: UUID) {
+        viewModelScope.launch {
+            _detailState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val plugin = apiClient.pluginsApi.getPlugin(id).unwrap()
+                _detailState.update { it.copy(plugin = plugin, isLoading = false) }
+            } catch (e: Exception) {
+                _detailState.update {
+                    it.copy(error = e.message ?: "Failed to load plugin", isLoading = false)
+                }
+            }
+        }
+    }
+
+    fun enablePlugin(id: UUID) = mutate("Plugin enabled", "Failed to enable plugin") {
+        apiClient.pluginsApi.enablePlugin(id).unwrap()
+    }
+
+    fun disablePlugin(id: UUID) = mutate("Plugin disabled", "Failed to disable plugin") {
+        apiClient.pluginsApi.disablePlugin(id).unwrap()
+    }
+
+    fun reloadPlugin(id: UUID) = mutate("Plugin reloaded", "Failed to reload plugin") {
+        apiClient.pluginsApi.reloadPlugin(id).unwrap()
+    }
+
+    fun uninstallPlugin(id: UUID) = mutate("Plugin uninstalled", "Failed to uninstall plugin") {
+        apiClient.pluginsApi.uninstallPlugin(id).unwrap()
+    }
+
+    fun installFromGit(url: String, ref: String?) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                val result = apiClient.pluginsApi.installFromGit(
+                    InstallFromGitRequest(url = url, ref = ref),
+                ).unwrap()
+                _uiState.update { it.copy(isMutating = false, message = result.message) }
+                loadPlugins()
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to install plugin", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun clearMessages() {
+        _uiState.update { it.copy(error = null, message = null) }
+    }
+
+    private fun mutate(successMessage: String, failureMessage: String, block: suspend () -> Unit) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                block()
+                _uiState.update { it.copy(isMutating = false, message = successMessage) }
+                loadPlugins()
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: failureMessage, isMutating = false)
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/PluginsViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/PluginsViewModelTest.kt
@@ -1,0 +1,245 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.integration.PluginDetailUiState
+import com.artifactkeeper.android.ui.screens.integration.PluginsUiState
+import com.artifactkeeper.android.ui.screens.integration.PluginsViewModel
+import com.artifactkeeper.client.apis.PluginsApi
+import com.artifactkeeper.client.models.InstallFromGitRequest
+import com.artifactkeeper.client.models.PluginInstallResponse
+import com.artifactkeeper.client.models.PluginListResponse
+import com.artifactkeeper.client.models.PluginResponse
+import com.artifactkeeper.client.models.WasmPluginResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PluginsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockPluginsApi = mockk<PluginsApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { pluginsApi } returns mockPluginsApi
+    }
+
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun plugin(name: String, status: String = "enabled", id: UUID = UUID.randomUUID()) = PluginResponse(
+        configSchema = emptyMap<String, Any>(),
+        displayName = name,
+        id = id,
+        installedAt = now,
+        name = name.lowercase(),
+        pluginType = "format",
+        status = status,
+        version = "1.0.0",
+    )
+
+    @Test
+    fun `initial list state is empty`() {
+        val state = PluginsUiState()
+        assertTrue(state.plugins.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertNull(state.message)
+    }
+
+    @Test
+    fun `initial detail state is empty`() {
+        val state = PluginDetailUiState()
+        assertNull(state.plugin)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadPlugins populates list sorted by name`() = runTest {
+        coEvery { mockPluginsApi.listPlugins(null, null) } returns Response.success(
+            PluginListResponse(items = listOf(plugin("Zebra"), plugin("Alpha"))),
+        )
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.loadPlugins()
+
+        val names = vm.uiState.value.plugins.map { it.displayName }
+        assertEquals(listOf("Alpha", "Zebra"), names)
+        assertFalse(vm.uiState.value.isLoading)
+        assertNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `loadPlugins sets error on failure`() = runTest {
+        coEvery { mockPluginsApi.listPlugins(null, null) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.loadPlugins()
+
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `loadPluginDetail calls getPlugin and populates detail`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPluginsApi.getPlugin(id) } returns Response.success(plugin("Maven", id = id))
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.loadPluginDetail(id)
+
+        coVerify { mockPluginsApi.getPlugin(id) }
+        assertEquals(id, vm.detailState.value.plugin?.id)
+        assertFalse(vm.detailState.value.isLoading)
+    }
+
+    @Test
+    fun `loadPluginDetail sets error on failure`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPluginsApi.getPlugin(id) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.loadPluginDetail(id)
+
+        assertNotNull(vm.detailState.value.error)
+        assertNull(vm.detailState.value.plugin)
+    }
+
+    @Test
+    fun `enablePlugin calls api and reloads`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPluginsApi.enablePlugin(id) } returns Response.success(Unit)
+        coEvery { mockPluginsApi.listPlugins(null, null) } returns Response.success(
+            PluginListResponse(items = listOf(plugin("Maven", status = "enabled", id = id))),
+        )
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.enablePlugin(id)
+
+        coVerify { mockPluginsApi.enablePlugin(id) }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `disablePlugin calls api`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPluginsApi.disablePlugin(id) } returns Response.success(Unit)
+        coEvery { mockPluginsApi.listPlugins(null, null) } returns Response.success(
+            PluginListResponse(items = emptyList()),
+        )
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.disablePlugin(id)
+
+        coVerify { mockPluginsApi.disablePlugin(id) }
+    }
+
+    @Test
+    fun `reloadPlugin calls api`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPluginsApi.reloadPlugin(id) } returns Response.success(
+            WasmPluginResponse(
+                capabilities = emptyMap<String, Any>(),
+                displayName = "Maven",
+                id = id,
+                installedAt = now,
+                name = "maven",
+                pluginType = "format",
+                resourceLimits = emptyMap<String, Any>(),
+                sourceType = "git",
+                status = "enabled",
+                updatedAt = now,
+                version = "1.0.0",
+            ),
+        )
+        coEvery { mockPluginsApi.listPlugins(null, null) } returns Response.success(
+            PluginListResponse(items = emptyList()),
+        )
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.reloadPlugin(id)
+
+        coVerify { mockPluginsApi.reloadPlugin(id) }
+    }
+
+    @Test
+    fun `uninstallPlugin calls api and reloads`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPluginsApi.uninstallPlugin(id) } returns Response.success(Unit)
+        coEvery { mockPluginsApi.listPlugins(null, null) } returns Response.success(
+            PluginListResponse(items = emptyList()),
+        )
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.uninstallPlugin(id)
+
+        coVerify { mockPluginsApi.uninstallPlugin(id) }
+        assertTrue(vm.uiState.value.plugins.isEmpty())
+    }
+
+    @Test
+    fun `installFromGit posts url and ref then reloads`() = runTest {
+        coEvery { mockPluginsApi.installFromGit(any()) } returns Response.success(
+            PluginInstallResponse(
+                formatKey = "unity",
+                message = "installed",
+                name = "unity",
+                pluginId = UUID.randomUUID(),
+                version = "1.0.0",
+            ),
+        )
+        coEvery { mockPluginsApi.listPlugins(null, null) } returns Response.success(
+            PluginListResponse(items = listOf(plugin("Unity"))),
+        )
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.installFromGit("https://github.com/x/y", "main")
+
+        coVerify {
+            mockPluginsApi.installFromGit(
+                InstallFromGitRequest(url = "https://github.com/x/y", ref = "main"),
+            )
+        }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `installFromGit sets error on failure`() = runTest {
+        coEvery { mockPluginsApi.installFromGit(any()) } returns
+            Response.error(400, okhttp3.ResponseBody.create(null, "bad url"))
+
+        val vm = PluginsViewModel(mockApiClient)
+        vm.installFromGit("not-a-url", null)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+}


### PR DESCRIPTION
## Summary
Second Android Integration cluster: adds a Plugins tab to the Integration section.

- `PluginsScreen` (new "Plugins" sub-tab) lists installed plugins (sorted) with **Enable**/**Disable**/**Reload** actions, **Uninstall** (confirm dialog), and an **install-from-Git** dialog (URL + optional ref via FAB).
- `PluginDetailScreen` (tap a plugin) loads via a real `getPlugin(id)` call on entry and shows type/version/status/description/install+enable timestamps/author/homepage.
- `PluginsViewModel` is Hilt-injected with loading/error/message states; mutations surface via snackbar and reload the list.
- Adds `PluginsApi` to the app's `ApiClient`.

Rebased onto current main (after #111). Nav-host reconciled to keep both the webhook detail drill-down (#111) and the new Plugins tab + plugin-detail drill-down. No parity-matrix edits.

Operations wired (previously missing):
- `list_plugins`, `get_plugin`, `enable_plugin`, `disable_plugin`, `reload_plugin`, `install_from_git`, `uninstall_plugin`

Deferred (noted, not built): `install_plugin` / `install_from_zip` / `install_from_local` (multipart file upload, not a mobile flow), `get_plugin_config` / `update_plugin_config` (free-form JSON authoring), `get_plugin_events`.

Closes #114
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`PluginsViewModelTest`: 12 tests (incl. coVerify of `getPlugin(id)`, install-from-git body, enable/disable/reload/uninstall, sort + error paths), all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes