### PR TITLE
feat(integration): peer detail with sync tasks and sync actions

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -45,6 +45,7 @@ import com.artifactkeeper.android.ui.screens.artifacts.ArtifactDetailScreen
 import com.artifactkeeper.android.ui.screens.artifacts.RepositoryBrowseScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildDetailScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildsScreen
+import com.artifactkeeper.android.ui.screens.integration.PeerDetailScreen
 import com.artifactkeeper.android.ui.screens.integration.PeersScreen
 import com.artifactkeeper.android.ui.screens.integration.ReplicationScreen
 import com.artifactkeeper.android.ui.screens.integration.PluginDetailScreen
@@ -590,6 +591,7 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
     var selectedTab by remember { mutableIntStateOf(0) }
     var selectedWebhookId by remember { mutableStateOf<String?>(null) }
     var selectedPluginId by remember { mutableStateOf<String?>(null) }
+    var selectedPeerId by remember { mutableStateOf<String?>(null) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         if (selectedWebhookId != null) {
@@ -601,6 +603,11 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
             PluginDetailScreen(
                 pluginId = selectedPluginId!!,
                 onBack = { selectedPluginId = null },
+            )
+        } else if (selectedPeerId != null) {
+            PeerDetailScreen(
+                peerId = selectedPeerId!!,
+                onBack = { selectedPeerId = null },
             )
         } else {
             TopAppBar(
@@ -621,7 +628,7 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
                 }
             }
             when (selectedTab) {
-                0 -> PeersScreen()
+                0 -> PeersScreen(onPeerClick = { selectedPeerId = it })
                 1 -> ReplicationScreen()
                 2 -> WebhooksScreen(onWebhookClick = { selectedWebhookId = it })
                 3 -> PluginsScreen(onPluginClick = { selectedPluginId = it })

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeerDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeerDetailScreen.kt
@@ -1,0 +1,290 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.PeerInstanceResponse
+import com.artifactkeeper.client.models.SyncTaskResponse
+import java.util.UUID
+
+private val OnlineColor = Color(0xFF52C41A)
+private val OfflineColor = Color(0xFFF5222D)
+private val PendingColor = Color(0xFFFAAD14)
+
+private fun peerStatusColor(status: String): Color = when (status.lowercase()) {
+    "online", "active", "healthy", "connected" -> OnlineColor
+    "offline", "unreachable", "error" -> OfflineColor
+    else -> PendingColor
+}
+
+/**
+ * Detail for a single peer instance: status and cache usage, a Sync now action,
+ * its assigned repositories (each syncable), and its recent sync tasks.
+ */
+@Composable
+fun PeerDetailScreen(
+    peerId: String,
+    onBack: () -> Unit,
+    viewModel: PeerDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val parsedId = remember(peerId) { runCatching { UUID.fromString(peerId) }.getOrNull() }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(parsedId) {
+        parsedId?.let { viewModel.load(it) }
+    }
+
+    LaunchedEffect(state.message, state.error, state.peer) {
+        val text = state.message ?: state.error?.takeIf { state.peer != null }
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearMessage()
+        }
+    }
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TopAppBar(
+                title = { Text(state.peer?.name ?: "Peer") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = { parsedId?.let { viewModel.triggerSync(it) } },
+                        enabled = parsedId != null && !state.isMutating,
+                    ) { Text("Sync now") }
+                },
+            )
+
+            when {
+                parsedId == null -> CenteredText("Invalid peer id")
+                state.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.error != null && state.peer == null -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = state.error ?: "Unknown error",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { viewModel.load(parsedId) }) { Text("Retry") }
+                        }
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        state.peer?.let { peer ->
+                            item { PeerStatusCard(peer) }
+                        }
+
+                        if (state.assignedRepoIds.isNotEmpty()) {
+                            item {
+                                Text(
+                                    text = "Assigned repositories (${state.assignedRepoIds.size})",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    modifier = Modifier.padding(top = 4.dp),
+                                )
+                            }
+                            items(state.assignedRepoIds, key = { it }) { repoId ->
+                                AssignedRepoCard(
+                                    repoId = repoId,
+                                    isMutating = state.isMutating,
+                                    onSyncNow = {
+                                        parsedId?.let { viewModel.runSubscriptionNow(it, repoId) }
+                                    },
+                                )
+                            }
+                        }
+
+                        item {
+                            Text(
+                                text = "Sync tasks (${state.syncTasks.size})",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                        if (state.syncTasks.isEmpty()) {
+                            item {
+                                Text(
+                                    text = "No active sync tasks",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        } else {
+                            items(state.syncTasks, key = { it.id }) { task ->
+                                SyncTaskCard(task)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PeerStatusCard(peer: PeerInstanceResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(text = peer.name, style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        text = peer.endpointUrl,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                PeerStatusBadge(peer.status)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Cache ${"%.0f".format(peer.cacheUsagePercent)}% used  -  ${peer.region ?: "no region"}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            peer.lastSyncAt?.let {
+                Text(
+                    text = "Last sync ${it.toLocalDate()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            peer.lastHeartbeatAt?.let {
+                Text(
+                    text = "Last heartbeat ${it.toLocalDate()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PeerStatusBadge(status: String) {
+    val color = peerStatusColor(status)
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = status.replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+private fun AssignedRepoCard(repoId: UUID, isMutating: Boolean, onSyncNow: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = repoId.toString(),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            TextButton(onClick = onSyncNow, enabled = !isMutating) { Text("Sync now") }
+        }
+    }
+}
+
+@Composable
+private fun SyncTaskCard(task: SyncTaskResponse) {
+    val color = peerStatusColor(task.status)
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = task.storageKey,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = "priority ${task.priority}  -  ${task.createdAt.toLocalDate()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(color.copy(alpha = 0.15f))
+                    .padding(horizontal = 10.dp, vertical = 4.dp),
+            ) {
+                Text(
+                    text = task.status.replaceFirstChar { it.uppercase() },
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = color,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CenteredText(text: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeerDetailViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeerDetailViewModel.kt
@@ -1,0 +1,117 @@
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.PeerInstanceResponse
+import com.artifactkeeper.client.models.SyncTaskResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for a single peer's detail: its instance status plus the sync tasks
+ * queued or running against it.
+ */
+data class PeerDetailUiState(
+    val peer: PeerInstanceResponse? = null,
+    val syncTasks: List<SyncTaskResponse> = emptyList(),
+    val assignedRepoIds: List<UUID> = emptyList(),
+    val isLoading: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+)
+
+@HiltViewModel
+class PeerDetailViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PeerDetailUiState())
+    val uiState: StateFlow<PeerDetailUiState> = _uiState.asStateFlow()
+
+    /**
+     * Load the peer instance and its sync tasks. The task list is optional: a
+     * peer with no in-flight sync should still render its status.
+     */
+    fun load(peerId: UUID) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val peer = apiClient.peersApi.getPeer(peerId).unwrap()
+
+                var tasks: List<SyncTaskResponse> = emptyList()
+                try {
+                    tasks = apiClient.peersApi.getSyncTasks(peerId).unwrap()
+                } catch (_: Exception) {
+                    // No sync tasks available.
+                }
+
+                var assignedRepoIds: List<UUID> = emptyList()
+                try {
+                    assignedRepoIds = apiClient.peersApi.getAssignedRepos(peerId).unwrap()
+                } catch (_: Exception) {
+                    // No assigned repositories available.
+                }
+
+                _uiState.update {
+                    it.copy(
+                        peer = peer,
+                        syncTasks = tasks,
+                        assignedRepoIds = assignedRepoIds,
+                        isLoading = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to load peer", isLoading = false)
+                }
+            }
+        }
+    }
+
+    /** Trigger a full sync for the peer, then reload. */
+    fun triggerSync(peerId: UUID) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.peersApi.triggerSync(peerId).unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Sync triggered") }
+                load(peerId)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to trigger sync", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /** Run a single repository subscription now, then reload. */
+    fun runSubscriptionNow(peerId: UUID, repoId: UUID) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                val result = apiClient.peersApi.runSubscriptionNow(peerId, repoId).unwrap()
+                _uiState.update {
+                    it.copy(isMutating = false, message = "${result.status} (${result.tasksQueued} queued)")
+                }
+                load(peerId)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to run subscription", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun clearMessage() {
+        _uiState.update { it.copy(message = null, error = null) }
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeersScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeersScreen.kt
@@ -3,6 +3,7 @@
 package com.artifactkeeper.android.ui.screens.integration
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -34,7 +35,7 @@ private val StatusOffline = Color(0xFFF5222D)
 private val StatusSyncing = Color(0xFFFA8C16)
 
 @Composable
-fun PeersScreen() {
+fun PeersScreen(onPeerClick: (String) -> Unit = {}) {
     var peers by remember { mutableStateOf<List<PeerInstance>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
     var isRefreshing by remember { mutableStateOf(false) }
@@ -119,6 +120,7 @@ fun PeersScreen() {
                         items(peers, key = { it.id }) { peer ->
                             PeerCard(
                                 peer = peer,
+                                onClick = { onPeerClick(peer.id.toString()) },
                                 onDelete = { peerToDelete = peer },
                             )
                         }
@@ -215,14 +217,14 @@ fun PeersScreen() {
 }
 
 @Composable
-private fun PeerCard(peer: PeerInstance, onDelete: () -> Unit) {
+private fun PeerCard(peer: PeerInstance, onClick: () -> Unit, onDelete: () -> Unit) {
     val statusColor = when (peer.status.lowercase()) {
         "online" -> StatusOnline
         "syncing" -> StatusSyncing
         else -> StatusOffline
     }
 
-    Card(modifier = Modifier.fillMaxWidth()) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/test/java/com/artifactkeeper/android/PeerDetailViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/PeerDetailViewModelTest.kt
@@ -1,0 +1,172 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.integration.PeerDetailUiState
+import com.artifactkeeper.android.ui.screens.integration.PeerDetailViewModel
+import com.artifactkeeper.client.apis.PeersApi
+import com.artifactkeeper.client.models.PeerInstanceResponse
+import com.artifactkeeper.client.models.RunNowResponse
+import com.artifactkeeper.client.models.SyncTaskResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PeerDetailViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockPeersApi = mockk<PeersApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { peersApi } returns mockPeersApi
+    }
+
+    private val peerId = UUID.randomUUID()
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun peer() = PeerInstanceResponse(
+        cacheSizeBytes = 1_000_000,
+        cacheUsagePercent = 42.0,
+        cacheUsedBytes = 420_000,
+        createdAt = now,
+        endpointUrl = "https://peer.test",
+        id = peerId,
+        isLocal = false,
+        name = "edge-1",
+        status = "online",
+    )
+
+    private fun task(status: String) = SyncTaskResponse(
+        artifactId = UUID.randomUUID(),
+        artifactSize = 123,
+        createdAt = now,
+        id = UUID.randomUUID(),
+        priority = 1,
+        status = status,
+        storageKey = "k",
+    )
+
+    @Test
+    fun `initial state is empty`() {
+        val state = PeerDetailUiState()
+        assertNull(state.peer)
+        assertTrue(state.syncTasks.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `load populates peer sync tasks and assigned repos`() = runTest {
+        val repoId = UUID.randomUUID()
+        coEvery { mockPeersApi.getPeer(peerId) } returns Response.success(peer())
+        coEvery { mockPeersApi.getSyncTasks(peerId, null, null, null, null) } returns Response.success(
+            listOf(task("queued"), task("completed")),
+        )
+        coEvery { mockPeersApi.getAssignedRepos(peerId) } returns Response.success(listOf(repoId))
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.load(peerId)
+
+        val state = vm.uiState.value
+        assertEquals(peerId, state.peer?.id)
+        assertEquals(2, state.syncTasks.size)
+        assertEquals(listOf(repoId), state.assignedRepoIds)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `load tolerates missing sync tasks`() = runTest {
+        coEvery { mockPeersApi.getPeer(peerId) } returns Response.success(peer())
+        coEvery { mockPeersApi.getSyncTasks(peerId, null, null, null, null) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "none"))
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.load(peerId)
+
+        assertNotNull(vm.uiState.value.peer)
+        assertTrue(vm.uiState.value.syncTasks.isEmpty())
+        assertNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `load sets error when peer fetch fails`() = runTest {
+        coEvery { mockPeersApi.getPeer(peerId) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.load(peerId)
+
+        assertNotNull(vm.uiState.value.error)
+        assertNull(vm.uiState.value.peer)
+    }
+
+    @Test
+    fun `triggerSync calls api and reloads`() = runTest {
+        coEvery { mockPeersApi.triggerSync(peerId) } returns Response.success(Unit)
+        coEvery { mockPeersApi.getPeer(peerId) } returns Response.success(peer())
+        coEvery { mockPeersApi.getSyncTasks(peerId, null, null, null, null) } returns Response.success(emptyList())
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.triggerSync(peerId)
+
+        coVerify { mockPeersApi.triggerSync(peerId) }
+        assertNotNull(vm.uiState.value.message)
+        assertFalse(vm.uiState.value.isMutating)
+    }
+
+    @Test
+    fun `triggerSync sets error on failure`() = runTest {
+        coEvery { mockPeersApi.triggerSync(peerId) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.triggerSync(peerId)
+
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isMutating)
+    }
+
+    @Test
+    fun `runSubscriptionNow calls api with repo id`() = runTest {
+        val repoId = UUID.randomUUID()
+        coEvery { mockPeersApi.runSubscriptionNow(peerId, repoId) } returns Response.success(
+            RunNowResponse(status = "queued", tasksQueued = 3),
+        )
+        coEvery { mockPeersApi.getPeer(peerId) } returns Response.success(peer())
+        coEvery { mockPeersApi.getSyncTasks(peerId, null, null, null, null) } returns Response.success(emptyList())
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.runSubscriptionNow(peerId, repoId)
+
+        coVerify { mockPeersApi.runSubscriptionNow(peerId, repoId) }
+        assertNotNull(vm.uiState.value.message)
+    }
+}


### PR DESCRIPTION
## Summary
First peers/federation cluster: adds a peer detail view to the Integration > Peers tab.

- Tapping a peer opens `PeerDetailScreen`: status + cache usage + region card, its assigned repositories (each with a **Sync now** action), and its recent sync tasks. A toolbar **Sync now** triggers a full peer sync.
- `PeerDetailViewModel` is Hilt-injected with loading/error/message states. Sync tasks and assigned repos are optional/non-destructive (loaded best-effort); mutation results surface via snackbar without blanking the screen.

Rebased onto current main (after #115). Nav-host reconciled to keep all three Integration drill-downs: webhook (#111), plugin (#115), and the new peer detail. Renamed the local status badge to avoid a same-package collision with the plugins `StatusBadge`. No parity-matrix edits.

Operations wired (previously missing):
- `get_peer`, `get_sync_tasks`, `get_assigned_repos`, `trigger_sync`, `run_subscription_now`

Deferred (noted, not built) — the rest of the 33 peer ops:
- Sync policies (list/get/toggle/evaluate) -> follow-up cluster; create/update/delete are authoring.
- Destructive / instance-internal: `unassign_repo`, `mark_unreachable`, `update_network_profile`, `announce_peer`, `discover_peers`, `probe_peer`, `heartbeat`.
- P2P transfer internals: all `chunks/*` and `transfer/*` (not a mobile flow).

Closes #116
Part of #80

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`PeerDetailViewModelTest`: 7 tests (incl. coVerify of `triggerSync` and `runSubscriptionNow(peerId, repoId)`, load + error + missing-tasks paths), all passing. `./gradlew assembleDebug` and `./gradlew :app:testDebugUnitTest` green.

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [ ] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes