### PR TITLE
feat(integration): sync policies list, toggle, evaluate, detail

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -48,6 +48,7 @@ import com.artifactkeeper.android.ui.screens.builds.BuildsScreen
 import com.artifactkeeper.android.ui.screens.integration.PeerDetailScreen
 import com.artifactkeeper.android.ui.screens.integration.PeersScreen
 import com.artifactkeeper.android.ui.screens.integration.ReplicationScreen
+import com.artifactkeeper.android.ui.screens.integration.SyncPoliciesScreen
 import com.artifactkeeper.android.ui.screens.integration.PluginDetailScreen
 import com.artifactkeeper.android.ui.screens.integration.PluginsScreen
 import com.artifactkeeper.android.ui.screens.integration.WebhookDetailScreen
@@ -587,7 +588,7 @@ private fun SectionWithTabs(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable () -> Unit) {
-    val subTabs = listOf("Peers", "Replication", "Webhooks", "Plugins")
+    val subTabs = listOf("Peers", "Replication", "Policies", "Webhooks", "Plugins")
     var selectedTab by remember { mutableIntStateOf(0) }
     var selectedWebhookId by remember { mutableStateOf<String?>(null) }
     var selectedPluginId by remember { mutableStateOf<String?>(null) }
@@ -630,8 +631,9 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
             when (selectedTab) {
                 0 -> PeersScreen(onPeerClick = { selectedPeerId = it })
                 1 -> ReplicationScreen()
-                2 -> WebhooksScreen(onWebhookClick = { selectedWebhookId = it })
-                3 -> PluginsScreen(onPluginClick = { selectedPluginId = it })
+                2 -> SyncPoliciesScreen()
+                3 -> WebhooksScreen(onWebhookClick = { selectedWebhookId = it })
+                4 -> PluginsScreen(onPluginClick = { selectedPluginId = it })
             }
         }
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/SyncPoliciesScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/SyncPoliciesScreen.kt
@@ -1,0 +1,294 @@
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.SyncPolicyResponse
+import com.artifactkeeper.android.ui.util.formatRelativeTime
+
+private val EnabledColor = Color(0xFF52C41A)
+private val DisabledColor = Color(0xFF8C8C8C)
+
+/**
+ * Replication sync policies: lists policies (highest priority first), toggles a
+ * policy's enabled flag, triggers a global evaluation, and opens a read-only
+ * detail loaded fresh by id. Policy authoring (create/update/delete/preview) is
+ * not exposed here.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SyncPoliciesScreen(
+    viewModel: SyncPoliciesViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val detailState by viewModel.detailState.collectAsState()
+    var policyToToggle by remember { mutableStateOf<SyncPolicyResponse?>(null) }
+    var showDetail by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(Unit) { viewModel.loadPolicies() }
+
+    LaunchedEffect(state.message, state.error) {
+        val text = state.message ?: state.error
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearMessages()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = { viewModel.evaluatePolicies() },
+                icon = { Icon(Icons.Default.PlayArrow, contentDescription = null) },
+                text = { Text("Evaluate") },
+                expanded = !state.isMutating,
+            )
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.error != null && state.policies.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = state.error ?: "Unknown error",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { viewModel.loadPolicies(refresh = true) }) {
+                                Text("Retry")
+                            }
+                        }
+                    }
+                }
+                state.policies.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "No sync policies configured.",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(state.policies, key = { it.id }) { policy ->
+                            SyncPolicyCard(
+                                policy = policy,
+                                isMutating = state.isMutating,
+                                onView = {
+                                    viewModel.loadPolicyDetail(policy.id)
+                                    showDetail = true
+                                },
+                                onToggle = { policyToToggle = policy },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    policyToToggle?.let { policy ->
+        val turningOn = !policy.enabled
+        AlertDialog(
+            onDismissRequest = { policyToToggle = null },
+            title = { Text(if (turningOn) "Enable policy" else "Disable policy") },
+            text = {
+                Text(
+                    if (turningOn) {
+                        "Enable \"${policy.name}\"? It will participate in the next evaluation."
+                    } else {
+                        "Disable \"${policy.name}\"? It will be skipped during evaluation."
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.togglePolicy(policy.id, enabled = turningOn)
+                    policyToToggle = null
+                }) {
+                    Text(if (turningOn) "Enable" else "Disable")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { policyToToggle = null }) { Text("Cancel") }
+            },
+        )
+    }
+
+    if (showDetail) {
+        SyncPolicyDetailDialog(
+            isLoading = detailState.isLoading,
+            policy = detailState.policy,
+            error = detailState.error,
+            onDismiss = { showDetail = false },
+        )
+    }
+}
+
+@Composable
+private fun SyncPolicyCard(
+    policy: SyncPolicyResponse,
+    isMutating: Boolean,
+    onView: () -> Unit,
+    onToggle: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Sync,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Text(
+                        text = policy.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                StatusBadge(enabled = policy.enabled)
+            }
+
+            if (policy.description.isNotBlank()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = policy.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${policy.replicationMode} - priority ${policy.priority}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                TextButton(onClick = onView) { Text("View") }
+                TextButton(onClick = onToggle, enabled = !isMutating) {
+                    Text(if (policy.enabled) "Disable" else "Enable")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusBadge(enabled: Boolean) {
+    val color = if (enabled) EnabledColor else DisabledColor
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = if (enabled) "Enabled" else "Disabled",
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+private fun SyncPolicyDetailDialog(
+    isLoading: Boolean,
+    policy: SyncPolicyResponse?,
+    error: String?,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(policy?.name ?: "Sync policy") },
+        text = {
+            when {
+                isLoading -> {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                error != null -> {
+                    Text(text = error, color = MaterialTheme.colorScheme.error)
+                }
+                policy != null -> {
+                    Column {
+                        DetailRow("Status", if (policy.enabled) "Enabled" else "Disabled")
+                        DetailRow("Mode", policy.replicationMode)
+                        DetailRow("Priority", policy.priority.toString())
+                        DetailRow("Precedence", policy.precedence.toString())
+                        if (policy.filter.isNotBlank()) {
+                            DetailRow("Filter", policy.filter)
+                        }
+                        if (policy.description.isNotBlank()) {
+                            DetailRow("Description", policy.description)
+                        }
+                        DetailRow("Updated", formatRelativeTime(policy.updatedAt))
+                    }
+                }
+                else -> {
+                    Text("No detail available.")
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+    )
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Column(modifier = Modifier.padding(vertical = 4.dp)) {
+        Text(text = label, style = MaterialTheme.typography.labelMedium)
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/SyncPoliciesViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/SyncPoliciesViewModel.kt
@@ -1,0 +1,149 @@
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.EvaluationResultResponse
+import com.artifactkeeper.client.models.SyncPolicyResponse
+import com.artifactkeeper.client.models.TogglePolicyPayload
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for the sync policies list screen.
+ */
+data class SyncPoliciesUiState(
+    val policies: List<SyncPolicyResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+)
+
+/**
+ * State for a single sync policy's detail view, loaded by id on entry.
+ */
+data class SyncPolicyDetailUiState(
+    val policy: SyncPolicyResponse? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * Read and operate actions for replication sync policies. Authoring (create,
+ * update, delete, preview) is deferred; this screen lists policies, opens a
+ * policy detail by id, toggles a policy's enabled flag, and triggers a global
+ * policy evaluation.
+ */
+@HiltViewModel
+class SyncPoliciesViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SyncPoliciesUiState())
+    val uiState: StateFlow<SyncPoliciesUiState> = _uiState.asStateFlow()
+
+    private val _detailState = MutableStateFlow(SyncPolicyDetailUiState())
+    val detailState: StateFlow<SyncPolicyDetailUiState> = _detailState.asStateFlow()
+
+    fun loadPolicies(refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val policies = apiClient.peersApi.listSyncPolicies().unwrap().items
+                    .sortedByDescending { it.priority }
+                _uiState.update {
+                    it.copy(
+                        policies = policies,
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load sync policies",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Load a single policy fresh by id for the detail view. This intentionally
+     * re-fetches rather than reusing the list item so detail reflects the
+     * server's current state.
+     */
+    fun loadPolicyDetail(policyId: UUID) {
+        viewModelScope.launch {
+            _detailState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val policy = apiClient.peersApi.getSyncPolicy(policyId).unwrap()
+                _detailState.update { it.copy(policy = policy, isLoading = false) }
+            } catch (e: Exception) {
+                _detailState.update {
+                    it.copy(error = e.message ?: "Failed to load policy", isLoading = false)
+                }
+            }
+        }
+    }
+
+    fun togglePolicy(policyId: UUID, enabled: Boolean) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null) }
+            try {
+                apiClient.peersApi.togglePolicy(policyId, TogglePolicyPayload(enabled = enabled)).unwrap()
+                _uiState.update {
+                    it.copy(
+                        isMutating = false,
+                        message = if (enabled) "Policy enabled" else "Policy disabled",
+                    )
+                }
+                loadPolicies(refresh = true)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to toggle policy", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun evaluatePolicies() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null) }
+            try {
+                val result = apiClient.peersApi.evaluatePolicies().unwrap()
+                _uiState.update {
+                    it.copy(isMutating = false, message = summarize(result))
+                }
+                loadPolicies(refresh = true)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to evaluate policies", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun clearMessages() {
+        _uiState.update { it.copy(message = null, error = null) }
+    }
+
+    private fun summarize(result: EvaluationResultResponse): String =
+        "Evaluated ${result.policiesEvaluated} policies: " +
+            "${result.created} created, ${result.updated} updated, ${result.removed} removed, " +
+            "${result.retroactiveTasksQueued} tasks queued"
+}

--- a/app/src/test/java/com/artifactkeeper/android/SyncPoliciesViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/SyncPoliciesViewModelTest.kt
@@ -1,0 +1,224 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.integration.SyncPoliciesUiState
+import com.artifactkeeper.android.ui.screens.integration.SyncPoliciesViewModel
+import com.artifactkeeper.client.apis.PeersApi
+import com.artifactkeeper.client.models.EvaluationResultResponse
+import com.artifactkeeper.client.models.SyncPolicyListResponse
+import com.artifactkeeper.client.models.SyncPolicyResponse
+import com.artifactkeeper.client.models.TogglePolicyPayload
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncPoliciesViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockPeersApi = mockk<PeersApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { peersApi } returns mockPeersApi
+    }
+
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun policy(
+        name: String,
+        enabled: Boolean = true,
+        id: UUID = UUID.randomUUID(),
+        priority: Int = 0,
+    ) = SyncPolicyResponse(
+        artifactFilter = emptyMap<String, String>(),
+        createdAt = now,
+        description = "desc for $name",
+        enabled = enabled,
+        filter = "*.tar.gz",
+        id = id,
+        name = name,
+        peerSelector = emptyMap<String, String>(),
+        precedence = 0,
+        priority = priority,
+        replicationMode = "pull",
+        repoSelector = emptyMap<String, String>(),
+        updatedAt = now,
+    )
+
+    // =========================================================================
+    // UI state
+    // =========================================================================
+
+    @Test
+    fun `initial state is empty`() {
+        val state = SyncPoliciesUiState()
+        assertTrue(state.policies.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertNull(state.message)
+    }
+
+    // =========================================================================
+    // loadPolicies
+    // =========================================================================
+
+    @Test
+    fun `loadPolicies populates policies sorted by priority`() = runTest {
+        coEvery { mockPeersApi.listSyncPolicies() } returns Response.success(
+            SyncPolicyListResponse(
+                items = listOf(
+                    policy("low", priority = 1),
+                    policy("high", priority = 10),
+                ),
+                total = 2,
+            ),
+        )
+
+        val vm = SyncPoliciesViewModel(mockApiClient)
+        vm.loadPolicies()
+
+        val state = vm.uiState.value
+        assertEquals(2, state.policies.size)
+        // higher priority sorts first
+        assertEquals("high", state.policies.first().name)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadPolicies sets error on failure`() = runTest {
+        coEvery { mockPeersApi.listSyncPolicies() } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = SyncPoliciesViewModel(mockApiClient)
+        vm.loadPolicies()
+
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    // =========================================================================
+    // loadPolicyDetail (per-id call, not list reuse)
+    // =========================================================================
+
+    @Test
+    fun `loadPolicyDetail fetches the policy by id`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPeersApi.getSyncPolicy(id) } returns Response.success(policy("detail", id = id))
+
+        val vm = SyncPoliciesViewModel(mockApiClient)
+        vm.loadPolicyDetail(id)
+
+        coVerify { mockPeersApi.getSyncPolicy(id) }
+        assertEquals("detail", vm.detailState.value.policy?.name)
+        assertFalse(vm.detailState.value.isLoading)
+    }
+
+    @Test
+    fun `loadPolicyDetail sets error on failure`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPeersApi.getSyncPolicy(id) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = SyncPoliciesViewModel(mockApiClient)
+        vm.loadPolicyDetail(id)
+
+        assertNotNull(vm.detailState.value.error)
+    }
+
+    // =========================================================================
+    // togglePolicy
+    // =========================================================================
+
+    @Test
+    fun `togglePolicy posts enabled payload and reloads`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPeersApi.togglePolicy(id, TogglePolicyPayload(enabled = false)) } returns
+            Response.success(policy("p", enabled = false, id = id))
+        coEvery { mockPeersApi.listSyncPolicies() } returns Response.success(
+            SyncPolicyListResponse(items = listOf(policy("p", enabled = false, id = id)), total = 1),
+        )
+
+        val vm = SyncPoliciesViewModel(mockApiClient)
+        vm.togglePolicy(id, enabled = false)
+
+        coVerify { mockPeersApi.togglePolicy(id, TogglePolicyPayload(enabled = false)) }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `togglePolicy sets error on failure`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockPeersApi.togglePolicy(id, any()) } returns
+            Response.error(409, okhttp3.ResponseBody.create(null, "conflict"))
+
+        val vm = SyncPoliciesViewModel(mockApiClient)
+        vm.togglePolicy(id, enabled = true)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+
+    // =========================================================================
+    // evaluatePolicies
+    // =========================================================================
+
+    @Test
+    fun `evaluatePolicies calls api and surfaces result summary`() = runTest {
+        coEvery { mockPeersApi.evaluatePolicies() } returns Response.success(
+            EvaluationResultResponse(
+                created = 3,
+                policiesEvaluated = 5,
+                removed = 1,
+                retroactiveTasksQueued = 2,
+                updated = 4,
+            ),
+        )
+        coEvery { mockPeersApi.listSyncPolicies() } returns Response.success(
+            SyncPolicyListResponse(items = emptyList(), total = 0),
+        )
+
+        val vm = SyncPoliciesViewModel(mockApiClient)
+        vm.evaluatePolicies()
+
+        coVerify { mockPeersApi.evaluatePolicies() }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `evaluatePolicies sets error on failure`() = runTest {
+        coEvery { mockPeersApi.evaluatePolicies() } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = SyncPoliciesViewModel(mockApiClient)
+        vm.evaluatePolicies()
+
+        assertNotNull(vm.uiState.value.error)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a Policies sub-tab to the Integration section covering replication sync policy reads and operate actions. Authoring is deferred.

Resolved ops (PeersApi):
- `listSyncPolicies` - list, sorted highest priority first
- `getSyncPolicy(id)` - detail loaded fresh by id on entry (LaunchedEffect -> loadPolicyDetail), not reused from the list object
- `togglePolicy(id, payload)` - enable/disable with a confirm dialog
- `evaluatePolicies` - global evaluation via the Evaluate FAB, surfaces a result summary

Deferred (free-form authoring): `createSyncPolicy`, `updateSyncPolicy`, `deleteSyncPolicy`, `previewSyncPolicy`.

Sub-tab order is now Peers / Replication / Policies / Webhooks / Plugins; index math updated, all existing drill-down routes (peer/webhook/plugin detail) preserved.

New files: `SyncPoliciesViewModel.kt`, `SyncPoliciesScreen.kt`, `SyncPoliciesViewModelTest.kt`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [x] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes

Closes #120
Part of #80