### PR TITLE
feat(integration): peer instance labels on peer detail

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -11,6 +11,7 @@ import com.artifactkeeper.client.apis.GroupsApi
 import com.artifactkeeper.client.apis.HealthApi
 import com.artifactkeeper.client.apis.MonitoringApi
 import com.artifactkeeper.client.apis.PackagesApi
+import com.artifactkeeper.client.apis.PeerInstanceLabelsApi
 import com.artifactkeeper.client.apis.PeersApi
 import com.artifactkeeper.client.apis.PluginsApi
 import com.artifactkeeper.client.apis.PromotionApi
@@ -63,6 +64,7 @@ object ApiClient {
     lateinit var usersApi: UsersApi private set
     lateinit var groupsApi: GroupsApi private set
     lateinit var peersApi: PeersApi private set
+    lateinit var peerInstanceLabelsApi: PeerInstanceLabelsApi private set
     lateinit var pluginsApi: PluginsApi private set
     lateinit var webhooksApi: WebhooksApi private set
     lateinit var analyticsApi: AnalyticsApi private set
@@ -131,6 +133,7 @@ object ApiClient {
         usersApi = client.createService(UsersApi::class.java)
         groupsApi = client.createService(GroupsApi::class.java)
         peersApi = client.createService(PeersApi::class.java)
+        peerInstanceLabelsApi = client.createService(PeerInstanceLabelsApi::class.java)
         pluginsApi = client.createService(PluginsApi::class.java)
         webhooksApi = client.createService(WebhooksApi::class.java)
         analyticsApi = client.createService(AnalyticsApi::class.java)

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeerDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeerDetailScreen.kt
@@ -18,8 +18,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.artifactkeeper.client.models.PeerInstanceResponse
+import com.artifactkeeper.client.models.PeerLabelResponse
 import com.artifactkeeper.client.models.SyncTaskResponse
 import java.util.UUID
 
@@ -46,6 +49,8 @@ fun PeerDetailScreen(
     val state by viewModel.uiState.collectAsState()
     val parsedId = remember(peerId) { runCatching { UUID.fromString(peerId) }.getOrNull() }
     val snackbarHostState = remember { SnackbarHostState() }
+    var showAddLabel by remember { mutableStateOf(false) }
+    var labelToDelete by remember { mutableStateOf<PeerLabelResponse?>(null) }
 
     LaunchedEffect(parsedId) {
         parsedId?.let { viewModel.load(it) }
@@ -72,6 +77,10 @@ fun PeerDetailScreen(
                     }
                 },
                 actions = {
+                    TextButton(
+                        onClick = { showAddLabel = true },
+                        enabled = parsedId != null && !state.isMutating,
+                    ) { Text("Add label") }
                     TextButton(
                         onClick = { parsedId?.let { viewModel.triggerSync(it) } },
                         enabled = parsedId != null && !state.isMutating,
@@ -106,6 +115,32 @@ fun PeerDetailScreen(
                     ) {
                         state.peer?.let { peer ->
                             item { PeerStatusCard(peer) }
+                        }
+
+                        item {
+                            Text(
+                                text = "Labels (${state.labels.size})",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                        if (state.labels.isEmpty()) {
+                            item {
+                                Text(
+                                    text = "No labels. Use Add label to set one.",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        } else {
+                            items(state.labels, key = { it.key }) { label ->
+                                PeerLabelCard(
+                                    label = label,
+                                    isMutating = state.isMutating,
+                                    onDelete = { labelToDelete = label },
+                                )
+                            }
                         }
 
                         if (state.assignedRepoIds.isNotEmpty()) {
@@ -154,6 +189,115 @@ fun PeerDetailScreen(
             }
         }
     }
+
+    if (showAddLabel) {
+        AddLabelDialog(
+            isMutating = state.isMutating,
+            onDismiss = { showAddLabel = false },
+            onConfirm = { key, value ->
+                parsedId?.let { viewModel.addLabel(it, key, value) }
+                showAddLabel = false
+            },
+        )
+    }
+
+    labelToDelete?.let { label ->
+        AlertDialog(
+            onDismissRequest = { labelToDelete = null },
+            title = { Text("Remove label") },
+            text = { Text("Remove label \"${label.key}\" from this peer?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    parsedId?.let { viewModel.deleteLabel(it, label.key) }
+                    labelToDelete = null
+                }) { Text("Remove") }
+            },
+            dismissButton = {
+                TextButton(onClick = { labelToDelete = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun PeerLabelCard(
+    label: PeerLabelResponse,
+    isMutating: Boolean,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = label.key,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (label.`value`.isNotBlank()) {
+                    Text(
+                        text = label.`value`,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            IconButton(onClick = onDelete, enabled = !isMutating) {
+                Icon(Icons.Default.Close, contentDescription = "Remove label ${label.key}")
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddLabelDialog(
+    isMutating: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (key: String, value: String) -> Unit,
+) {
+    var key by remember { mutableStateOf("") }
+    var value by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add label") },
+        icon = { Icon(Icons.Default.Add, contentDescription = null) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = key,
+                    onValueChange = { key = it },
+                    label = { Text("Key") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    label = { Text("Value (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(key.trim(), value.trim()) },
+                enabled = !isMutating && key.isNotBlank(),
+            ) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeerDetailViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/PeerDetailViewModel.kt
@@ -4,7 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.artifactkeeper.android.data.api.ApiClient
 import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.AddPeerLabelRequest
 import com.artifactkeeper.client.models.PeerInstanceResponse
+import com.artifactkeeper.client.models.PeerLabelEntrySchema
+import com.artifactkeeper.client.models.PeerLabelResponse
+import com.artifactkeeper.client.models.SetPeerLabelsRequest
 import com.artifactkeeper.client.models.SyncTaskResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +27,7 @@ data class PeerDetailUiState(
     val peer: PeerInstanceResponse? = null,
     val syncTasks: List<SyncTaskResponse> = emptyList(),
     val assignedRepoIds: List<UUID> = emptyList(),
+    val labels: List<PeerLabelResponse> = emptyList(),
     val isLoading: Boolean = false,
     val isMutating: Boolean = false,
     val error: String? = null,
@@ -61,11 +66,19 @@ class PeerDetailViewModel @Inject constructor(
                     // No assigned repositories available.
                 }
 
+                var labels: List<PeerLabelResponse> = emptyList()
+                try {
+                    labels = apiClient.peerInstanceLabelsApi.listLabels(peerId).unwrap().items
+                } catch (_: Exception) {
+                    // No labels available.
+                }
+
                 _uiState.update {
                     it.copy(
                         peer = peer,
                         syncTasks = tasks,
                         assignedRepoIds = assignedRepoIds,
+                        labels = labels.sortedBy { label -> label.key },
                         isLoading = false,
                     )
                 }
@@ -106,6 +119,58 @@ class PeerDetailViewModel @Inject constructor(
             } catch (e: Exception) {
                 _uiState.update {
                     it.copy(error = e.message ?: "Failed to run subscription", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /** Add or update a single label on the peer, then reload. */
+    fun addLabel(peerId: UUID, key: String, value: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.peerInstanceLabelsApi
+                    .addLabel(peerId, key, AddPeerLabelRequest(value = value.ifBlank { null }))
+                    .unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Label \"$key\" saved") }
+                load(peerId)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to add label", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /** Delete a single label by key, then reload. */
+    fun deleteLabel(peerId: UUID, key: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.peerInstanceLabelsApi.deleteLabel(peerId, key).unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Label \"$key\" removed") }
+                load(peerId)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to delete label", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /** Replace the peer's full label set in one call, then reload. */
+    fun setLabels(peerId: UUID, labels: List<PeerLabelEntrySchema>) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.peerInstanceLabelsApi
+                    .setLabels(peerId, SetPeerLabelsRequest(labels = labels))
+                    .unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Labels replaced") }
+                load(peerId)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to set labels", isMutating = false)
                 }
             }
         }

--- a/app/src/test/java/com/artifactkeeper/android/PeerDetailViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/PeerDetailViewModelTest.kt
@@ -3,9 +3,15 @@ package com.artifactkeeper.android
 import com.artifactkeeper.android.data.api.ApiClient
 import com.artifactkeeper.android.ui.screens.integration.PeerDetailUiState
 import com.artifactkeeper.android.ui.screens.integration.PeerDetailViewModel
+import com.artifactkeeper.client.apis.PeerInstanceLabelsApi
 import com.artifactkeeper.client.apis.PeersApi
+import com.artifactkeeper.client.models.AddPeerLabelRequest
 import com.artifactkeeper.client.models.PeerInstanceResponse
+import com.artifactkeeper.client.models.PeerLabelEntrySchema
+import com.artifactkeeper.client.models.PeerLabelResponse
+import com.artifactkeeper.client.models.PeerLabelsListResponse
 import com.artifactkeeper.client.models.RunNowResponse
+import com.artifactkeeper.client.models.SetPeerLabelsRequest
 import com.artifactkeeper.client.models.SyncTaskResponse
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -34,8 +40,10 @@ class PeerDetailViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val mockPeersApi = mockk<PeersApi>()
+    private val mockLabelsApi = mockk<PeerInstanceLabelsApi>()
     private val mockApiClient = mockk<ApiClient> {
         every { peersApi } returns mockPeersApi
+        every { peerInstanceLabelsApi } returns mockLabelsApi
     }
 
     private val peerId = UUID.randomUUID()
@@ -61,6 +69,14 @@ class PeerDetailViewModelTest {
         isLocal = false,
         name = "edge-1",
         status = "online",
+    )
+
+    private fun label(key: String, value: String = "v-$key") = PeerLabelResponse(
+        createdAt = now,
+        id = UUID.randomUUID(),
+        key = key,
+        peerInstanceId = peerId,
+        `value` = value,
     )
 
     private fun task(status: String) = SyncTaskResponse(
@@ -90,6 +106,9 @@ class PeerDetailViewModelTest {
             listOf(task("queued"), task("completed")),
         )
         coEvery { mockPeersApi.getAssignedRepos(peerId) } returns Response.success(listOf(repoId))
+        coEvery { mockLabelsApi.listLabels(peerId) } returns Response.success(
+            PeerLabelsListResponse(items = listOf(label("region"), label("env")), total = 2),
+        )
 
         val vm = PeerDetailViewModel(mockApiClient)
         vm.load(peerId)
@@ -98,6 +117,8 @@ class PeerDetailViewModelTest {
         assertEquals(peerId, state.peer?.id)
         assertEquals(2, state.syncTasks.size)
         assertEquals(listOf(repoId), state.assignedRepoIds)
+        // labels sorted by key
+        assertEquals(listOf("env", "region"), state.labels.map { it.key })
         assertFalse(state.isLoading)
         assertNull(state.error)
     }
@@ -168,5 +189,99 @@ class PeerDetailViewModelTest {
 
         coVerify { mockPeersApi.runSubscriptionNow(peerId, repoId) }
         assertNotNull(vm.uiState.value.message)
+    }
+
+    // =========================================================================
+    // peer instance labels
+    // =========================================================================
+
+    private fun stubReload() {
+        coEvery { mockPeersApi.getPeer(peerId) } returns Response.success(peer())
+        coEvery { mockPeersApi.getSyncTasks(peerId, null, null, null, null) } returns Response.success(emptyList())
+        coEvery { mockPeersApi.getAssignedRepos(peerId) } returns Response.success(emptyList())
+        coEvery { mockLabelsApi.listLabels(peerId) } returns Response.success(
+            PeerLabelsListResponse(items = emptyList(), total = 0),
+        )
+    }
+
+    @Test
+    fun `addLabel posts key and value then reloads`() = runTest {
+        coEvery { mockLabelsApi.addLabel(peerId, "env", AddPeerLabelRequest(value = "prod")) } returns
+            Response.success(label("env", "prod"))
+        stubReload()
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.addLabel(peerId, key = "env", value = "prod")
+
+        coVerify { mockLabelsApi.addLabel(peerId, "env", AddPeerLabelRequest(value = "prod")) }
+        coVerify { mockLabelsApi.listLabels(peerId) }
+        assertNotNull(vm.uiState.value.message)
+        assertFalse(vm.uiState.value.isMutating)
+    }
+
+    @Test
+    fun `addLabel sets error on failure`() = runTest {
+        coEvery { mockLabelsApi.addLabel(peerId, "env", any()) } returns
+            Response.error(400, okhttp3.ResponseBody.create(null, "bad"))
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.addLabel(peerId, key = "env", value = "prod")
+
+        assertNotNull(vm.uiState.value.error)
+        assertFalse(vm.uiState.value.isMutating)
+    }
+
+    @Test
+    fun `deleteLabel calls api with key then reloads`() = runTest {
+        coEvery { mockLabelsApi.deleteLabel(peerId, "env") } returns Response.success(Unit)
+        stubReload()
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.deleteLabel(peerId, key = "env")
+
+        coVerify { mockLabelsApi.deleteLabel(peerId, "env") }
+        coVerify { mockLabelsApi.listLabels(peerId) }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `deleteLabel sets error on failure`() = runTest {
+        coEvery { mockLabelsApi.deleteLabel(peerId, "env") } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.deleteLabel(peerId, key = "env")
+
+        assertNotNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `setLabels replaces full label set then reloads`() = runTest {
+        val entries = listOf(
+            PeerLabelEntrySchema(key = "env", `value` = "prod"),
+            PeerLabelEntrySchema(key = "region", `value` = "us-east"),
+        )
+        coEvery { mockLabelsApi.setLabels(peerId, SetPeerLabelsRequest(labels = entries)) } returns
+            Response.success(
+                PeerLabelsListResponse(items = listOf(label("env", "prod"), label("region", "us-east")), total = 2),
+            )
+        stubReload()
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.setLabels(peerId, entries)
+
+        coVerify { mockLabelsApi.setLabels(peerId, SetPeerLabelsRequest(labels = entries)) }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `setLabels sets error on failure`() = runTest {
+        coEvery { mockLabelsApi.setLabels(peerId, any()) } returns
+            Response.error(422, okhttp3.ResponseBody.create(null, "invalid"))
+
+        val vm = PeerDetailViewModel(mockApiClient)
+        vm.setLabels(peerId, listOf(PeerLabelEntrySchema(key = "env", `value` = "prod")))
+
+        assertNotNull(vm.uiState.value.error)
     }
 }


### PR DESCRIPTION
## Summary
Adds peer instance labels to the existing peer detail screen. Labels load best-effort alongside the peer's sync tasks and assigned repos.

Resolved ops (PeerInstanceLabelsApi, via PeerDetailViewModel + ApiClient, real-method coVerify tests with runtime UUIDs):
- `listLabels(id)` - loaded in PeerDetailViewModel.load, sorted by key
- `addLabel(id, key, body)` - Add label dialog (key + optional value)
- `deleteLabel(id, key)` - per-label remove with a confirm dialog

`setLabels(id, body)` (full replacement) is implemented and unit-tested in the ViewModel; its UI surface is deferred because bulk replace is closer to authoring.

Registers `PeerInstanceLabelsApi` in `ApiClient`. No nav/index changes (labels live inside the existing peer detail).

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [x] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes

Closes #122
Part of #80