### PR TITLE
feat(integration): migration jobs list, detail, operate actions

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -9,6 +9,7 @@ import com.artifactkeeper.client.apis.AuthApi
 import com.artifactkeeper.client.apis.BuildsApi
 import com.artifactkeeper.client.apis.GroupsApi
 import com.artifactkeeper.client.apis.HealthApi
+import com.artifactkeeper.client.apis.MigrationApi
 import com.artifactkeeper.client.apis.MonitoringApi
 import com.artifactkeeper.client.apis.PackagesApi
 import com.artifactkeeper.client.apis.PeerInstanceLabelsApi
@@ -68,6 +69,7 @@ object ApiClient {
     lateinit var pluginsApi: PluginsApi private set
     lateinit var webhooksApi: WebhooksApi private set
     lateinit var analyticsApi: AnalyticsApi private set
+    lateinit var migrationApi: MigrationApi private set
     lateinit var monitoringApi: MonitoringApi private set
     lateinit var healthApi: HealthApi private set
     lateinit var sbomApi: SbomApi private set
@@ -137,6 +139,7 @@ object ApiClient {
         pluginsApi = client.createService(PluginsApi::class.java)
         webhooksApi = client.createService(WebhooksApi::class.java)
         analyticsApi = client.createService(AnalyticsApi::class.java)
+        migrationApi = client.createService(MigrationApi::class.java)
         monitoringApi = client.createService(MonitoringApi::class.java)
         healthApi = client.createService(HealthApi::class.java)
         sbomApi = client.createService(SbomApi::class.java)

--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -47,6 +47,8 @@ import com.artifactkeeper.android.ui.screens.builds.BuildDetailScreen
 import com.artifactkeeper.android.ui.screens.builds.BuildsScreen
 import com.artifactkeeper.android.ui.screens.integration.PeerDetailScreen
 import com.artifactkeeper.android.ui.screens.integration.PeersScreen
+import com.artifactkeeper.android.ui.screens.integration.MigrationScreen
+import com.artifactkeeper.android.ui.screens.integration.MigrationDetailScreen
 import com.artifactkeeper.android.ui.screens.integration.ReplicationScreen
 import com.artifactkeeper.android.ui.screens.integration.SyncPoliciesScreen
 import com.artifactkeeper.android.ui.screens.integration.PluginDetailScreen
@@ -588,11 +590,12 @@ private fun SectionWithTabs(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable () -> Unit) {
-    val subTabs = listOf("Peers", "Replication", "Policies", "Webhooks", "Plugins")
+    val subTabs = listOf("Peers", "Replication", "Policies", "Webhooks", "Plugins", "Migration")
     var selectedTab by remember { mutableIntStateOf(0) }
     var selectedWebhookId by remember { mutableStateOf<String?>(null) }
     var selectedPluginId by remember { mutableStateOf<String?>(null) }
     var selectedPeerId by remember { mutableStateOf<String?>(null) }
+    var selectedMigrationId by remember { mutableStateOf<String?>(null) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         if (selectedWebhookId != null) {
@@ -609,6 +612,11 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
             PeerDetailScreen(
                 peerId = selectedPeerId!!,
                 onBack = { selectedPeerId = null },
+            )
+        } else if (selectedMigrationId != null) {
+            MigrationDetailScreen(
+                jobId = selectedMigrationId!!,
+                onBack = { selectedMigrationId = null },
             )
         } else {
             TopAppBar(
@@ -634,6 +642,7 @@ private fun IntegrationSection(isCompact: Boolean, accountActions: @Composable (
                 2 -> SyncPoliciesScreen()
                 3 -> WebhooksScreen(onWebhookClick = { selectedWebhookId = it })
                 4 -> PluginsScreen(onPluginClick = { selectedPluginId = it })
+                5 -> MigrationScreen(onJobClick = { selectedMigrationId = it })
             }
         }
     }

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/MigrationDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/MigrationDetailScreen.kt
@@ -1,0 +1,370 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.AssessmentResult
+import com.artifactkeeper.client.models.MigrationItemResponse
+import com.artifactkeeper.client.models.MigrationJobResponse
+import com.artifactkeeper.android.ui.util.formatBytes
+import java.util.UUID
+
+/**
+ * Detail for a single migration job: progress and counts, operate actions
+ * (assess, start, pause, resume, cancel) gated by status, the latest
+ * assessment, and the job's items.
+ */
+@Composable
+fun MigrationDetailScreen(
+    jobId: String,
+    onBack: () -> Unit,
+    viewModel: MigrationViewModel = hiltViewModel(),
+) {
+    val state by viewModel.detailState.collectAsState()
+    val parsedId = remember(jobId) { runCatching { UUID.fromString(jobId) }.getOrNull() }
+    val snackbarHostState = remember { SnackbarHostState() }
+    var pendingAction by remember { mutableStateOf<Pair<String, () -> Unit>?>(null) }
+
+    LaunchedEffect(parsedId) {
+        parsedId?.let { viewModel.loadDetail(it) }
+    }
+
+    LaunchedEffect(state.message, state.error, state.job) {
+        val text = state.message ?: state.error?.takeIf { state.job != null }
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearMessage()
+        }
+    }
+
+    Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TopAppBar(
+                title = { Text(state.job?.jobType ?: "Migration") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+
+            when {
+                parsedId == null -> CenteredMigrationText("Invalid migration id")
+                state.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.error != null && state.job == null -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = state.error ?: "Unknown error",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { viewModel.loadDetail(parsedId) }) { Text("Retry") }
+                        }
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        state.job?.let { job ->
+                            item { MigrationProgressCard(job) }
+                            item {
+                                MigrationActions(
+                                    status = job.status,
+                                    isMutating = state.isMutating,
+                                    onAssess = {
+                                        pendingAction = "Run assessment for this job?" to {
+                                            parsedId?.let { viewModel.assess(it) }
+                                        }
+                                    },
+                                    onStart = {
+                                        pendingAction = "Start this migration?" to {
+                                            parsedId?.let { viewModel.start(it) }
+                                        }
+                                    },
+                                    onPause = {
+                                        pendingAction = "Pause this migration?" to {
+                                            parsedId?.let { viewModel.pause(it) }
+                                        }
+                                    },
+                                    onResume = {
+                                        pendingAction = "Resume this migration?" to {
+                                            parsedId?.let { viewModel.resume(it) }
+                                        }
+                                    },
+                                    onCancel = {
+                                        pendingAction = "Cancel this migration? This cannot be undone." to {
+                                            parsedId?.let { viewModel.cancel(it) }
+                                        }
+                                    },
+                                    onLoadAssessment = { parsedId?.let { viewModel.loadAssessment(it) } },
+                                )
+                            }
+                        }
+
+                        state.assessment?.let { assessment ->
+                            item { AssessmentCard(assessment) }
+                        }
+
+                        item {
+                            Text(
+                                text = "Items (${state.items.size})",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
+                        if (state.items.isEmpty()) {
+                            item {
+                                Text(
+                                    text = "No items recorded for this job.",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        } else {
+                            items(state.items, key = { it.id }) { item ->
+                                MigrationItemCard(item)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pendingAction?.let { (message, action) ->
+        AlertDialog(
+            onDismissRequest = { pendingAction = null },
+            title = { Text("Confirm") },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = {
+                    action()
+                    pendingAction = null
+                }) { Text("Confirm") }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingAction = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun MigrationProgressCard(job: MigrationJobResponse) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(text = job.jobType, style = MaterialTheme.typography.titleMedium)
+                MigrationStatusBadge(job.status)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { (job.progressPercent / 100.0).toFloat().coerceIn(0f, 1f) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "${job.completedItems}/${job.totalItems} items - ${"%.0f".format(job.progressPercent)}%",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "${formatBytes(job.transferredBytes)} of ${formatBytes(job.totalBytes)} transferred",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (job.failedItems > 0 || job.skippedItems > 0) {
+                Text(
+                    text = "${job.failedItems} failed, ${job.skippedItems} skipped",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            job.errorSummary?.takeIf { it.isNotBlank() }?.let { summary ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MigrationActions(
+    status: String,
+    isMutating: Boolean,
+    onAssess: () -> Unit,
+    onStart: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onCancel: () -> Unit,
+    onLoadAssessment: () -> Unit,
+) {
+    val s = status.lowercase()
+    val canStart = s in setOf("pending", "assessed", "ready", "created")
+    val canPause = s in setOf("running", "in_progress", "started")
+    val canResume = s == "paused"
+    val canCancel = s in setOf("pending", "running", "in_progress", "started", "paused", "assessed", "ready")
+
+    FlowRowActions {
+        TextButton(onClick = onAssess, enabled = !isMutating) { Text("Assess") }
+        TextButton(onClick = onLoadAssessment, enabled = !isMutating) { Text("View assessment") }
+        if (canStart) TextButton(onClick = onStart, enabled = !isMutating) { Text("Start") }
+        if (canPause) TextButton(onClick = onPause, enabled = !isMutating) { Text("Pause") }
+        if (canResume) TextButton(onClick = onResume, enabled = !isMutating) { Text("Resume") }
+        if (canCancel) {
+            TextButton(
+                onClick = onCancel,
+                enabled = !isMutating,
+                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+            ) { Text("Cancel") }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun FlowRowActions(content: @Composable () -> Unit) {
+    androidx.compose.foundation.layout.FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) { content() }
+}
+
+@Composable
+private fun AssessmentCard(assessment: AssessmentResult) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Assessment (${assessment.status})",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${assessment.totalArtifacts} artifacts, ${formatBytes(assessment.totalSizeBytes)}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "${assessment.repositories.size} repositories, ${assessment.usersCount} users, " +
+                    "${assessment.groupsCount} groups, ${assessment.permissionsCount} permissions",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (assessment.blockers.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text("Blockers", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.error)
+                assessment.blockers.forEach { blocker ->
+                    Text(
+                        text = "- $blocker",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+            if (assessment.warnings.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text("Warnings", style = MaterialTheme.typography.labelMedium)
+                assessment.warnings.forEach { warning ->
+                    Text(
+                        text = "- $warning",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MigrationItemCard(item: MigrationItemResponse) {
+    val color = migrationStatusColor(item.status)
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.sourcePath,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = "${item.itemType} - ${formatBytes(item.sizeBytes)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                item.errorMessage?.takeIf { it.isNotBlank() }?.let { msg ->
+                    Text(
+                        text = msg,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(color.copy(alpha = 0.15f))
+                    .padding(horizontal = 10.dp, vertical = 4.dp),
+            ) {
+                Text(
+                    text = item.status.replaceFirstChar { it.uppercase() },
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = color,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CenteredMigrationText(text: String) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/MigrationScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/MigrationScreen.kt
@@ -1,0 +1,152 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.MigrationJobResponse
+
+private val RunningColor = Color(0xFF1677FF)
+private val DoneColor = Color(0xFF52C41A)
+private val FailedColor = Color(0xFFF5222D)
+private val PausedColor = Color(0xFFFAAD14)
+
+internal fun migrationStatusColor(status: String): Color = when (status.lowercase()) {
+    "running", "in_progress", "started" -> RunningColor
+    "completed", "succeeded", "done" -> DoneColor
+    "failed", "cancelled", "canceled", "error" -> FailedColor
+    "paused" -> PausedColor
+    else -> PausedColor
+}
+
+/**
+ * Migration jobs list. Tapping a job opens its detail (status, items, and
+ * operate actions). Creating migrations and connections is not exposed here.
+ */
+@Composable
+fun MigrationScreen(
+    onJobClick: (String) -> Unit,
+    viewModel: MigrationViewModel = hiltViewModel(),
+) {
+    val state by viewModel.listState.collectAsState()
+
+    LaunchedEffect(Unit) { viewModel.loadJobs() }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        when {
+            state.isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            state.error != null && state.jobs.isEmpty() -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = state.error ?: "Unknown error",
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TextButton(onClick = { viewModel.loadJobs(refresh = true) }) {
+                            Text("Retry")
+                        }
+                    }
+                }
+            }
+            state.jobs.isEmpty() -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(
+                        text = "No migration jobs.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            else -> {
+                LazyColumn(
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    items(state.jobs, key = { it.id }) { job ->
+                        MigrationJobCard(job = job, onClick = { onJobClick(job.id.toString()) })
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MigrationJobCard(job: MigrationJobResponse, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = job.jobType,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                MigrationStatusBadge(job.status)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = { (job.progressPercent / 100.0).toFloat().coerceIn(0f, 1f) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${job.completedItems}/${job.totalItems} items  -  ${"%.0f".format(job.progressPercent)}%",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (job.failedItems > 0) {
+                Text(
+                    text = "${job.failedItems} failed",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun MigrationStatusBadge(status: String) {
+    val color = migrationStatusColor(status)
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = status.replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/MigrationViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/integration/MigrationViewModel.kt
@@ -1,0 +1,162 @@
+package com.artifactkeeper.android.ui.screens.integration
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.AssessmentResult
+import com.artifactkeeper.client.models.MigrationItemResponse
+import com.artifactkeeper.client.models.MigrationJobResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for the migration jobs list.
+ */
+data class MigrationListUiState(
+    val jobs: List<MigrationJobResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * State for a single migration job's detail: the job, its items, and an
+ * optional assessment result.
+ */
+data class MigrationDetailUiState(
+    val job: MigrationJobResponse? = null,
+    val items: List<MigrationItemResponse> = emptyList(),
+    val assessment: AssessmentResult? = null,
+    val isLoading: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+)
+
+/**
+ * Migration jobs: read the job list and a job's detail (items + assessment),
+ * and operate on a job (start, assess, pause, resume, cancel). Connection and
+ * migration authoring (create/delete) and progress streaming are deferred.
+ */
+@HiltViewModel
+class MigrationViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _listState = MutableStateFlow(MigrationListUiState())
+    val listState: StateFlow<MigrationListUiState> = _listState.asStateFlow()
+
+    private val _detailState = MutableStateFlow(MigrationDetailUiState())
+    val detailState: StateFlow<MigrationDetailUiState> = _detailState.asStateFlow()
+
+    fun loadJobs(refresh: Boolean = false) {
+        viewModelScope.launch {
+            _listState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val jobs = apiClient.migrationApi.listMigrations().unwrap()
+                _listState.update {
+                    it.copy(jobs = jobs, isLoading = false, isRefreshing = false)
+                }
+            } catch (e: Exception) {
+                _listState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load migrations",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Load a single job fresh by id for the detail view. Items are best-effort:
+     * a job with no items should still render its status.
+     */
+    fun loadDetail(jobId: UUID) {
+        viewModelScope.launch {
+            _detailState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val job = apiClient.migrationApi.getMigration(jobId).unwrap()
+
+                var items: List<MigrationItemResponse> = emptyList()
+                try {
+                    items = apiClient.migrationApi.listMigrationItems(jobId).unwrap()
+                } catch (_: Exception) {
+                    // No items available.
+                }
+
+                _detailState.update {
+                    it.copy(job = job, items = items, isLoading = false)
+                }
+            } catch (e: Exception) {
+                _detailState.update {
+                    it.copy(error = e.message ?: "Failed to load migration", isLoading = false)
+                }
+            }
+        }
+    }
+
+    /** Load the latest assessment for the job into the detail state. */
+    fun loadAssessment(jobId: UUID) {
+        viewModelScope.launch {
+            try {
+                val assessment = apiClient.migrationApi.getAssessment(jobId).unwrap()
+                _detailState.update { it.copy(assessment = assessment) }
+            } catch (e: Exception) {
+                _detailState.update {
+                    it.copy(error = e.message ?: "Failed to load assessment")
+                }
+            }
+        }
+    }
+
+    fun start(jobId: UUID) = operate(jobId, "Migration started") {
+        apiClient.migrationApi.startMigration(jobId).unwrap()
+    }
+
+    fun assess(jobId: UUID) = operate(jobId, "Assessment started") {
+        apiClient.migrationApi.runAssessment(jobId).unwrap()
+    }
+
+    fun pause(jobId: UUID) = operate(jobId, "Migration paused") {
+        apiClient.migrationApi.pauseMigration(jobId).unwrap()
+    }
+
+    fun resume(jobId: UUID) = operate(jobId, "Migration resumed") {
+        apiClient.migrationApi.resumeMigration(jobId).unwrap()
+    }
+
+    fun cancel(jobId: UUID) = operate(jobId, "Migration cancelled") {
+        apiClient.migrationApi.cancelMigration(jobId).unwrap()
+    }
+
+    fun clearMessage() {
+        _detailState.update { it.copy(message = null, error = null) }
+    }
+
+    private fun operate(jobId: UUID, successMessage: String, action: suspend () -> Unit) {
+        viewModelScope.launch {
+            _detailState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                action()
+                _detailState.update { it.copy(isMutating = false, message = successMessage) }
+                loadDetail(jobId)
+            } catch (e: Exception) {
+                _detailState.update {
+                    it.copy(error = e.message ?: "Action failed", isMutating = false)
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/MigrationViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/MigrationViewModelTest.kt
@@ -1,0 +1,292 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.integration.MigrationDetailUiState
+import com.artifactkeeper.android.ui.screens.integration.MigrationListUiState
+import com.artifactkeeper.android.ui.screens.integration.MigrationViewModel
+import com.artifactkeeper.client.apis.MigrationApi
+import com.artifactkeeper.client.models.AssessmentResult
+import com.artifactkeeper.client.models.MigrationItemResponse
+import com.artifactkeeper.client.models.MigrationJobResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MigrationViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockMigrationApi = mockk<MigrationApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { migrationApi } returns mockMigrationApi
+    }
+
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun job(
+        status: String = "running",
+        id: UUID = UUID.randomUUID(),
+        progress: Double = 50.0,
+    ) = MigrationJobResponse(
+        completedItems = 5,
+        config = emptyMap<String, String>(),
+        createdAt = now,
+        failedItems = 0,
+        id = id,
+        jobType = "artifactory",
+        progressPercent = progress,
+        skippedItems = 0,
+        sourceConnectionId = UUID.randomUUID(),
+        status = status,
+        totalBytes = 1000,
+        totalItems = 10,
+        transferredBytes = 500,
+    )
+
+    private fun item(status: String = "completed") = MigrationItemResponse(
+        id = UUID.randomUUID(),
+        itemType = "artifact",
+        jobId = UUID.randomUUID(),
+        retryCount = 0,
+        sizeBytes = 123,
+        sourcePath = "repo/a.jar",
+        status = status,
+    )
+
+    private fun assessment(jobId: UUID) = AssessmentResult(
+        blockers = emptyList(),
+        estimatedDurationSeconds = 600,
+        groupsCount = 2,
+        jobId = jobId,
+        permissionsCount = 3,
+        repositories = emptyList(),
+        status = "ready",
+        totalArtifacts = 100,
+        totalSizeBytes = 5000,
+        usersCount = 4,
+        warnings = listOf("slow source"),
+    )
+
+    // =========================================================================
+    // list
+    // =========================================================================
+
+    @Test
+    fun `initial list state is empty`() {
+        val state = MigrationListUiState()
+        assertTrue(state.jobs.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `loadJobs populates jobs`() = runTest {
+        coEvery { mockMigrationApi.listMigrations(null, null, null) } returns Response.success(
+            listOf(job(status = "running"), job(status = "completed")),
+        )
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.loadJobs()
+
+        assertEquals(2, vm.listState.value.jobs.size)
+        assertFalse(vm.listState.value.isLoading)
+        assertNull(vm.listState.value.error)
+    }
+
+    @Test
+    fun `loadJobs sets error on failure`() = runTest {
+        coEvery { mockMigrationApi.listMigrations(null, null, null) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.loadJobs()
+
+        assertNotNull(vm.listState.value.error)
+    }
+
+    // =========================================================================
+    // detail (per-id fetch, items + assessment best-effort)
+    // =========================================================================
+
+    @Test
+    fun `loadDetail fetches job and items by id`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.getMigration(id) } returns Response.success(job(id = id))
+        coEvery { mockMigrationApi.listMigrationItems(id, null, null, null, null) } returns
+            Response.success(listOf(item("completed"), item("failed")))
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.loadDetail(id)
+
+        coVerify { mockMigrationApi.getMigration(id) }
+        coVerify { mockMigrationApi.listMigrationItems(id, null, null, null, null) }
+        assertEquals(id, vm.detailState.value.job?.id)
+        assertEquals(2, vm.detailState.value.items.size)
+        assertFalse(vm.detailState.value.isLoading)
+    }
+
+    @Test
+    fun `loadDetail tolerates missing items`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.getMigration(id) } returns Response.success(job(id = id))
+        coEvery { mockMigrationApi.listMigrationItems(id, null, null, null, null) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "none"))
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.loadDetail(id)
+
+        assertNotNull(vm.detailState.value.job)
+        assertTrue(vm.detailState.value.items.isEmpty())
+        assertNull(vm.detailState.value.error)
+    }
+
+    @Test
+    fun `loadDetail sets error when job fetch fails`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.getMigration(id) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.loadDetail(id)
+
+        assertNotNull(vm.detailState.value.error)
+        assertNull(vm.detailState.value.job)
+    }
+
+    @Test
+    fun `loadAssessment fetches assessment by id`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.getAssessment(id) } returns Response.success(assessment(id))
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.loadAssessment(id)
+
+        coVerify { mockMigrationApi.getAssessment(id) }
+        assertEquals(id, vm.detailState.value.assessment?.jobId)
+    }
+
+    // =========================================================================
+    // operate actions
+    // =========================================================================
+
+    private fun stubDetailReload(id: UUID) {
+        coEvery { mockMigrationApi.getMigration(id) } returns Response.success(job(id = id))
+        coEvery { mockMigrationApi.listMigrationItems(id, null, null, null, null) } returns
+            Response.success(emptyList())
+    }
+
+    @Test
+    fun `start calls api and reloads detail`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.startMigration(id) } returns Response.success(job(id = id, status = "running"))
+        stubDetailReload(id)
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.start(id)
+
+        coVerify { mockMigrationApi.startMigration(id) }
+        assertNotNull(vm.detailState.value.message)
+        assertFalse(vm.detailState.value.isMutating)
+    }
+
+    @Test
+    fun `assess calls runAssessment and reloads detail`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.runAssessment(id) } returns Response.success(job(id = id))
+        stubDetailReload(id)
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.assess(id)
+
+        coVerify { mockMigrationApi.runAssessment(id) }
+        assertNotNull(vm.detailState.value.message)
+    }
+
+    @Test
+    fun `pause calls api and reloads detail`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.pauseMigration(id) } returns Response.success(job(id = id, status = "paused"))
+        stubDetailReload(id)
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.pause(id)
+
+        coVerify { mockMigrationApi.pauseMigration(id) }
+        assertNotNull(vm.detailState.value.message)
+    }
+
+    @Test
+    fun `resume calls api and reloads detail`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.resumeMigration(id) } returns Response.success(job(id = id, status = "running"))
+        stubDetailReload(id)
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.resume(id)
+
+        coVerify { mockMigrationApi.resumeMigration(id) }
+        assertNotNull(vm.detailState.value.message)
+    }
+
+    @Test
+    fun `cancel calls api and reloads detail`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.cancelMigration(id) } returns Response.success(job(id = id, status = "cancelled"))
+        stubDetailReload(id)
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.cancel(id)
+
+        coVerify { mockMigrationApi.cancelMigration(id) }
+        assertNotNull(vm.detailState.value.message)
+    }
+
+    @Test
+    fun `cancel sets error on failure`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockMigrationApi.cancelMigration(id) } returns
+            Response.error(409, okhttp3.ResponseBody.create(null, "conflict"))
+
+        val vm = MigrationViewModel(mockApiClient)
+        vm.cancel(id)
+
+        assertNotNull(vm.detailState.value.error)
+        assertFalse(vm.detailState.value.isMutating)
+    }
+
+    @Test
+    fun `initial detail state is empty`() {
+        val state = MigrationDetailUiState()
+        assertNull(state.job)
+        assertTrue(state.items.isEmpty())
+        assertNull(state.assessment)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a Migration sub-tab to the Integration section: a jobs list, a job detail loaded fresh by id, and operate actions.

Resolved ops (MigrationApi, via MigrationViewModel + ApiClient, real-method coVerify tests with runtime UUIDs):
- `listMigrations` - jobs list with progress
- `getMigration(id)` - detail loaded by id on entry (LaunchedEffect -> loadDetail)
- `listMigrationItems(id)` - items, best-effort
- `getAssessment(id)` - on-demand via View assessment
- `startMigration` / `runAssessment` / `pauseMigration` / `resumeMigration` / `cancelMigration` - status-gated buttons, each behind a confirm dialog

Sub-tab order is Peers / Replication / Policies / Webhooks / Plugins / Migration (Migration appended at index 5; rebased on top of the merged Policies tab, index math redone, all existing drill-down routes preserved). Registers `MigrationApi` in `ApiClient`.

Deferred (authoring / streaming): create/delete connection, create/delete migration, report export, source-repository listing, connection list/get/test, progress streaming.

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [x] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes

Closes #124
Part of #80