### PR TITLE
feat(artifacts): repository labels and access tokens

### DIFF
--- a/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
+++ b/app/src/main/java/com/artifactkeeper/android/data/api/ApiClient.kt
@@ -18,6 +18,8 @@ import com.artifactkeeper.client.apis.PluginsApi
 import com.artifactkeeper.client.apis.PromotionApi
 import com.artifactkeeper.client.apis.QualityApi
 import com.artifactkeeper.client.apis.RepositoriesApi
+import com.artifactkeeper.client.apis.RepositoryLabelsApi
+import com.artifactkeeper.client.apis.RepositoryTokensApi
 import com.artifactkeeper.client.apis.SbomApi
 import com.artifactkeeper.client.apis.SearchApi
 import com.artifactkeeper.client.apis.SecurityApi
@@ -58,6 +60,8 @@ object ApiClient {
     lateinit var artifactsApi: ArtifactsApi private set
     lateinit var artifactLabelsApi: ArtifactLabelsApi private set
     lateinit var reposApi: RepositoriesApi private set
+    lateinit var repositoryLabelsApi: RepositoryLabelsApi private set
+    lateinit var repositoryTokensApi: RepositoryTokensApi private set
     lateinit var packagesApi: PackagesApi private set
     lateinit var buildsApi: BuildsApi private set
     lateinit var securityApi: SecurityApi private set
@@ -128,6 +132,8 @@ object ApiClient {
         artifactsApi = client.createService(ArtifactsApi::class.java)
         artifactLabelsApi = client.createService(ArtifactLabelsApi::class.java)
         reposApi = client.createService(RepositoriesApi::class.java)
+        repositoryLabelsApi = client.createService(RepositoryLabelsApi::class.java)
+        repositoryTokensApi = client.createService(RepositoryTokensApi::class.java)
         packagesApi = client.createService(PackagesApi::class.java)
         buildsApi = client.createService(BuildsApi::class.java)
         securityApi = client.createService(SecurityApi::class.java)

--- a/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/ArtifactKeeperNavHost.kt
@@ -61,6 +61,8 @@ import com.artifactkeeper.android.ui.screens.operations.TelemetryScreen
 import com.artifactkeeper.android.ui.screens.packages.PackageDetailScreen
 import com.artifactkeeper.android.ui.screens.packages.PackagesScreen
 import com.artifactkeeper.android.ui.screens.repositories.CreateRepositoryScreen
+import com.artifactkeeper.android.ui.screens.repositories.RepoLabelsScreen
+import com.artifactkeeper.android.ui.screens.repositories.RepoTokensScreen
 import com.artifactkeeper.android.ui.screens.repositories.RepositoriesScreen
 import com.artifactkeeper.android.ui.screens.repositories.RepositoryDetailScreen
 import com.artifactkeeper.android.ui.screens.repositories.VirtualMembersScreen
@@ -770,6 +772,26 @@ private fun NavGraphBuilder.detailRoutes(navController: NavHostController) {
             onNavigateToRepoSecurity = { repoKey, repoName ->
                 navController.navigate("repos/$repoKey/security?name=$repoName")
             },
+            onNavigateToLabels = { repoKey ->
+                navController.navigate("repos/$repoKey/labels")
+            },
+            onNavigateToTokens = { repoKey ->
+                navController.navigate("repos/$repoKey/tokens")
+            },
+        )
+    }
+    composable("repos/{key}/labels") { backStackEntry ->
+        val key = backStackEntry.arguments?.getString("key") ?: return@composable
+        RepoLabelsScreen(
+            repoKey = key,
+            onBack = { navController.popBackStack() },
+        )
+    }
+    composable("repos/{key}/tokens") { backStackEntry ->
+        val key = backStackEntry.arguments?.getString("key") ?: return@composable
+        RepoTokensScreen(
+            repoKey = key,
+            onBack = { navController.popBackStack() },
         )
     }
     composable("repos/{key}/security?name={name}") { backStackEntry ->

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepoLabelsScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepoLabelsScreen.kt
@@ -1,0 +1,221 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.artifactkeeper.android.ui.screens.repositories
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.LabelResponse
+
+/**
+ * Labels for a single repository: list, add (key + optional value), and remove
+ * a label by key with a confirm dialog.
+ */
+@Composable
+fun RepoLabelsScreen(
+    repoKey: String,
+    onBack: () -> Unit,
+    viewModel: RepoLabelsViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    var showAdd by remember { mutableStateOf(false) }
+    var labelToDelete by remember { mutableStateOf<LabelResponse?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(repoKey) { viewModel.load(repoKey) }
+
+    LaunchedEffect(state.message, state.error) {
+        val text = state.message ?: state.error
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearMessages()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Labels - $repoKey", maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showAdd = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Add label")
+            }
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.error != null && state.labels.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = state.error ?: "Unknown error",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { viewModel.load(repoKey, refresh = true) }) {
+                                Text("Retry")
+                            }
+                        }
+                    }
+                }
+                state.labels.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "No labels. Use + to add one.",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(state.labels, key = { it.key }) { label ->
+                            RepoLabelCard(
+                                label = label,
+                                isMutating = state.isMutating,
+                                onDelete = { labelToDelete = label },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showAdd) {
+        AddRepoLabelDialog(
+            isMutating = state.isMutating,
+            onDismiss = { showAdd = false },
+            onConfirm = { key, value ->
+                viewModel.addLabel(repoKey, key, value)
+                showAdd = false
+            },
+        )
+    }
+
+    labelToDelete?.let { label ->
+        AlertDialog(
+            onDismissRequest = { labelToDelete = null },
+            title = { Text("Remove label") },
+            text = { Text("Remove label \"${label.key}\" from this repository?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteLabel(repoKey, label.key)
+                    labelToDelete = null
+                }) { Text("Remove") }
+            },
+            dismissButton = {
+                TextButton(onClick = { labelToDelete = null }) { Text("Cancel") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun RepoLabelCard(
+    label: LabelResponse,
+    isMutating: Boolean,
+    onDelete: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = label.key,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (label.`value`.isNotBlank()) {
+                    Text(
+                        text = label.`value`,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            IconButton(onClick = onDelete, enabled = !isMutating) {
+                Icon(Icons.Default.Close, contentDescription = "Remove label ${label.key}")
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddRepoLabelDialog(
+    isMutating: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (key: String, value: String) -> Unit,
+) {
+    var key by remember { mutableStateOf("") }
+    var value by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add label") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = key,
+                    onValueChange = { key = it },
+                    label = { Text("Key") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    label = { Text("Value (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(key.trim(), value.trim()) },
+                enabled = !isMutating && key.isNotBlank(),
+            ) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepoLabelsViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepoLabelsViewModel.kt
@@ -1,0 +1,100 @@
+package com.artifactkeeper.android.ui.screens.repositories
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.AddLabelRequest
+import com.artifactkeeper.client.models.LabelResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * State for a repository's labels.
+ */
+data class RepoLabelsUiState(
+    val labels: List<LabelResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+)
+
+/**
+ * Repository labels: list a repo's labels, add or update a single label, and
+ * remove a label by key. Bulk replacement (setRepoLabels) is deferred.
+ */
+@HiltViewModel
+class RepoLabelsViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RepoLabelsUiState())
+    val uiState: StateFlow<RepoLabelsUiState> = _uiState.asStateFlow()
+
+    fun load(repoKey: String, refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val labels = apiClient.repositoryLabelsApi.listRepoLabels(repoKey).unwrap().items
+                    .sortedBy { it.key }
+                _uiState.update {
+                    it.copy(labels = labels, isLoading = false, isRefreshing = false)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load labels",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    fun addLabel(repoKey: String, key: String, value: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.repositoryLabelsApi
+                    .addRepoLabel(repoKey, key, AddLabelRequest(value = value.ifBlank { null }))
+                    .unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Label \"$key\" saved") }
+                load(repoKey, refresh = true)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to add label", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun deleteLabel(repoKey: String, key: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.repositoryLabelsApi.deleteRepoLabel(repoKey, key).unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Label \"$key\" removed") }
+                load(repoKey, refresh = true)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to delete label", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun clearMessages() {
+        _uiState.update { it.copy(message = null, error = null) }
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepoTokensScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepoTokensScreen.kt
@@ -1,0 +1,375 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.artifactkeeper.android.ui.screens.repositories
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.artifactkeeper.client.models.RepoTokenResponse
+
+private val ActiveColor = Color(0xFF52C41A)
+private val RevokedColor = Color(0xFFF5222D)
+
+/** Scopes offered in the create-token dialog. */
+private val TokenScopes = listOf("read", "write", "delete", "admin")
+
+/**
+ * Access tokens for a single repository: list, create (the plaintext token is
+ * shown once), view a token's detail by id, and revoke a token with a confirm
+ * dialog.
+ */
+@Composable
+fun RepoTokensScreen(
+    repoKey: String,
+    onBack: () -> Unit,
+    viewModel: RepoTokensViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val detailState by viewModel.tokenDetailState.collectAsState()
+    var showCreate by remember { mutableStateOf(false) }
+    var tokenToRevoke by remember { mutableStateOf<RepoTokenResponse?>(null) }
+    var showDetail by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(repoKey) { viewModel.load(repoKey) }
+
+    LaunchedEffect(state.message, state.error) {
+        val text = state.message ?: state.error
+        if (text != null) {
+            snackbarHostState.showSnackbar(text)
+            viewModel.clearMessages()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Tokens - $repoKey", maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreate = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Create token")
+            }
+        },
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.isLoading -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                state.error != null && state.tokens.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = state.error ?: "Unknown error",
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { viewModel.load(repoKey, refresh = true) }) {
+                                Text("Retry")
+                            }
+                        }
+                    }
+                }
+                state.tokens.isEmpty() -> {
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "No tokens. Use + to create one.",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(state.tokens, key = { it.id }) { token ->
+                            RepoTokenCard(
+                                token = token,
+                                isMutating = state.isMutating,
+                                onView = {
+                                    viewModel.loadTokenDetail(repoKey, token.id)
+                                    showDetail = true
+                                },
+                                onRevoke = { tokenToRevoke = token },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreate) {
+        CreateTokenDialog(
+            isMutating = state.isMutating,
+            onDismiss = { showCreate = false },
+            onConfirm = { name, scopes, expiresInDays ->
+                viewModel.createToken(repoKey, name, scopes, expiresInDays)
+                showCreate = false
+            },
+        )
+    }
+
+    state.newTokenSecret?.let { secret ->
+        AlertDialog(
+            onDismissRequest = { viewModel.clearNewTokenSecret() },
+            title = { Text("Copy your token now") },
+            text = {
+                Column {
+                    Text(
+                        text = "This is the only time the token is shown. Store it somewhere safe.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = secret,
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { viewModel.clearNewTokenSecret() }) { Text("Done") }
+            },
+        )
+    }
+
+    tokenToRevoke?.let { token ->
+        AlertDialog(
+            onDismissRequest = { tokenToRevoke = null },
+            title = { Text("Revoke token") },
+            text = { Text("Revoke \"${token.name}\"? Anything using it will lose access.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.revokeToken(repoKey, token.id)
+                    tokenToRevoke = null
+                }) { Text("Revoke") }
+            },
+            dismissButton = {
+                TextButton(onClick = { tokenToRevoke = null }) { Text("Cancel") }
+            },
+        )
+    }
+
+    if (showDetail) {
+        TokenDetailDialog(
+            isLoading = detailState.isLoading,
+            token = detailState.token,
+            error = detailState.error,
+            onDismiss = { showDetail = false },
+        )
+    }
+}
+
+@Composable
+private fun RepoTokenCard(
+    token: RepoTokenResponse,
+    isMutating: Boolean,
+    onView: () -> Unit,
+    onRevoke: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = token.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                TokenStatusBadge(revoked = token.isRevoked, expired = token.isExpired)
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "${token.tokenPrefix}... - ${token.scopes.joinToString(", ")}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                TextButton(onClick = onView) { Text("View") }
+                if (!token.isRevoked) {
+                    TextButton(onClick = onRevoke, enabled = !isMutating) { Text("Revoke") }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TokenStatusBadge(revoked: Boolean, expired: Boolean) {
+    val (text, color) = when {
+        revoked -> "Revoked" to RevokedColor
+        expired -> "Expired" to RevokedColor
+        else -> "Active" to ActiveColor
+    }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(color.copy(alpha = 0.15f))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+        )
+    }
+}
+
+@Composable
+private fun CreateTokenDialog(
+    isMutating: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (name: String, scopes: List<String>, expiresInDays: Long?) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    val selectedScopes = remember { mutableStateListOf("read") }
+    var expiresText by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Create token") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text("Scopes", style = MaterialTheme.typography.labelMedium)
+                TokenScopes.forEach { scope ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = selectedScopes.contains(scope),
+                            onCheckedChange = { checked ->
+                                if (checked) selectedScopes.add(scope) else selectedScopes.remove(scope)
+                            },
+                        )
+                        Text(scope)
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = expiresText,
+                    onValueChange = { expiresText = it.filter { c -> c.isDigit() } },
+                    label = { Text("Expires in days (optional)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirm(name.trim(), selectedScopes.toList(), expiresText.toLongOrNull())
+                },
+                enabled = !isMutating && name.isNotBlank() && selectedScopes.isNotEmpty(),
+            ) { Text("Create") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}
+
+@Composable
+private fun TokenDetailDialog(
+    isLoading: Boolean,
+    token: RepoTokenResponse?,
+    error: String?,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(token?.name ?: "Token") },
+        text = {
+            when {
+                isLoading -> {
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                error != null -> {
+                    Text(text = error, color = MaterialTheme.colorScheme.error)
+                }
+                token != null -> {
+                    Column {
+                        DetailRow("Prefix", "${token.tokenPrefix}...")
+                        DetailRow("Scopes", token.scopes.joinToString(", "))
+                        token.description?.takeIf { it.isNotBlank() }?.let { DetailRow("Description", it) }
+                        token.createdBy?.takeIf { it.isNotBlank() }?.let { DetailRow("Created by", it) }
+                        DetailRow("Created", token.createdAt.toLocalDate().toString())
+                        token.expiresAt?.let { DetailRow("Expires", it.toLocalDate().toString()) }
+                        token.lastUsedAt?.let { DetailRow("Last used", it.toLocalDate().toString()) }
+                        DetailRow(
+                            "Status",
+                            when {
+                                token.isRevoked -> "Revoked"
+                                token.isExpired -> "Expired"
+                                else -> "Active"
+                            },
+                        )
+                    }
+                }
+                else -> Text("No detail available.")
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+    )
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Column(modifier = Modifier.padding(vertical = 4.dp)) {
+        Text(text = label, style = MaterialTheme.typography.labelMedium)
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepoTokensViewModel.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepoTokensViewModel.kt
@@ -1,0 +1,148 @@
+package com.artifactkeeper.android.ui.screens.repositories
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.data.api.unwrap
+import com.artifactkeeper.client.models.CreateRepoTokenRequest
+import com.artifactkeeper.client.models.RepoTokenResponse
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * State for a repository's access tokens. [newTokenSecret] holds the one-time
+ * plaintext token returned on creation; it is shown once and then cleared.
+ */
+data class RepoTokensUiState(
+    val tokens: List<RepoTokenResponse> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isMutating: Boolean = false,
+    val error: String? = null,
+    val message: String? = null,
+    val newTokenSecret: String? = null,
+)
+
+/**
+ * State for a single token's detail, fetched fresh by id.
+ */
+data class RepoTokenDetailUiState(
+    val token: RepoTokenResponse? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+/**
+ * Repository access tokens: list a repo's tokens, view a single token by id,
+ * create a token (the plaintext is returned once on creation), and revoke a
+ * token by id.
+ */
+@HiltViewModel
+class RepoTokensViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RepoTokensUiState())
+    val uiState: StateFlow<RepoTokensUiState> = _uiState.asStateFlow()
+
+    private val _tokenDetailState = MutableStateFlow(RepoTokenDetailUiState())
+    val tokenDetailState: StateFlow<RepoTokenDetailUiState> = _tokenDetailState.asStateFlow()
+
+    fun load(repoKey: String, refresh: Boolean = false) {
+        viewModelScope.launch {
+            _uiState.update {
+                if (refresh) it.copy(isRefreshing = true, error = null)
+                else it.copy(isLoading = true, error = null)
+            }
+            try {
+                val tokens = apiClient.repositoryTokensApi.listRepoTokens(repoKey).unwrap().items
+                    .sortedBy { it.isRevoked }
+                _uiState.update {
+                    it.copy(tokens = tokens, isLoading = false, isRefreshing = false)
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        error = e.message ?: "Failed to load tokens",
+                        isLoading = false,
+                        isRefreshing = false,
+                    )
+                }
+            }
+        }
+    }
+
+    /** Load a single token fresh by id for the detail view. */
+    fun loadTokenDetail(repoKey: String, tokenId: UUID) {
+        viewModelScope.launch {
+            _tokenDetailState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val token = apiClient.repositoryTokensApi.getRepoToken(repoKey, tokenId).unwrap()
+                _tokenDetailState.update { it.copy(token = token, isLoading = false) }
+            } catch (e: Exception) {
+                _tokenDetailState.update {
+                    it.copy(error = e.message ?: "Failed to load token", isLoading = false)
+                }
+            }
+        }
+    }
+
+    fun createToken(
+        repoKey: String,
+        name: String,
+        scopes: List<String>,
+        expiresInDays: Long?,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                val created = apiClient.repositoryTokensApi.createRepoToken(
+                    repoKey,
+                    CreateRepoTokenRequest(name = name, scopes = scopes, expiresInDays = expiresInDays),
+                ).unwrap()
+                _uiState.update {
+                    it.copy(
+                        isMutating = false,
+                        message = "Token \"$name\" created",
+                        newTokenSecret = created.token,
+                    )
+                }
+                load(repoKey, refresh = true)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to create token", isMutating = false)
+                }
+            }
+        }
+    }
+
+    fun revokeToken(repoKey: String, tokenId: UUID) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isMutating = true, error = null, message = null) }
+            try {
+                apiClient.repositoryTokensApi.revokeRepoToken(repoKey, tokenId).unwrap()
+                _uiState.update { it.copy(isMutating = false, message = "Token revoked") }
+                load(repoKey, refresh = true)
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(error = e.message ?: "Failed to revoke token", isMutating = false)
+                }
+            }
+        }
+    }
+
+    /** Clear the one-time plaintext token after the user has copied it. */
+    fun clearNewTokenSecret() {
+        _uiState.update { it.copy(newTokenSecret = null) }
+    }
+
+    fun clearMessages() {
+        _uiState.update { it.copy(message = null, error = null) }
+    }
+}

--- a/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
+++ b/app/src/main/java/com/artifactkeeper/android/ui/screens/repositories/RepositoryDetailScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Label
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.Upload
@@ -53,6 +55,8 @@ fun RepositoryDetailScreen(
     onArtifactSecurityClick: (id: String, name: String) -> Unit = { _, _ -> },
     onNavigateToMembers: ((repoKey: String, repoName: String, repoFormat: String) -> Unit)? = null,
     onNavigateToRepoSecurity: ((repoKey: String, repoName: String) -> Unit)? = null,
+    onNavigateToLabels: ((repoKey: String) -> Unit)? = null,
+    onNavigateToTokens: ((repoKey: String) -> Unit)? = null,
 ) {
     var repository by remember { mutableStateOf<Repository?>(null) }
     var artifacts by remember { mutableStateOf<List<Artifact>>(emptyList()) }
@@ -241,6 +245,30 @@ fun RepositoryDetailScreen(
                                         onClick = {
                                             onNavigateToRepoSecurity.invoke(repo.key, repo.name)
                                         },
+                                    )
+                                }
+                            }
+
+                            // Labels card
+                            if (onNavigateToLabels != null) {
+                                item(key = "repo-labels") {
+                                    RepoNavCard(
+                                        icon = Icons.Default.Label,
+                                        title = "Labels",
+                                        subtitle = "View and manage this repository's labels",
+                                        onClick = { onNavigateToLabels.invoke(repo.key) },
+                                    )
+                                }
+                            }
+
+                            // Tokens card
+                            if (onNavigateToTokens != null) {
+                                item(key = "repo-tokens") {
+                                    RepoNavCard(
+                                        icon = Icons.Default.Key,
+                                        title = "Access tokens",
+                                        subtitle = "Create and revoke repository access tokens",
+                                        onClick = { onNavigateToTokens.invoke(repo.key) },
                                     )
                                 }
                             }
@@ -596,6 +624,48 @@ private fun RepoSecurityCard(onClick: () -> Unit) {
                 )
                 Text(
                     text = "View this repository's security score, scan configuration, and scans",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = "Navigate",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RepoNavCard(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                icon,
+                contentDescription = title,
+                modifier = Modifier.size(24.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(text = title, style = MaterialTheme.typography.titleMedium)
+                Text(
+                    text = subtitle,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/test/java/com/artifactkeeper/android/RepoLabelsViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/RepoLabelsViewModelTest.kt
@@ -1,0 +1,146 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.repositories.RepoLabelsUiState
+import com.artifactkeeper.android.ui.screens.repositories.RepoLabelsViewModel
+import com.artifactkeeper.client.apis.RepositoryLabelsApi
+import com.artifactkeeper.client.models.AddLabelRequest
+import com.artifactkeeper.client.models.LabelResponse
+import com.artifactkeeper.client.models.LabelsListResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RepoLabelsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockLabelsApi = mockk<RepositoryLabelsApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { repositoryLabelsApi } returns mockLabelsApi
+    }
+
+    private val repoKey = "maven-releases"
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun label(key: String, value: String = "v-$key") = LabelResponse(
+        createdAt = now,
+        id = UUID.randomUUID(),
+        key = key,
+        repositoryId = UUID.randomUUID(),
+        `value` = value,
+    )
+
+    @Test
+    fun `initial state is empty`() {
+        val state = RepoLabelsUiState()
+        assertTrue(state.labels.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `load populates labels sorted by key`() = runTest {
+        coEvery { mockLabelsApi.listRepoLabels(repoKey) } returns Response.success(
+            LabelsListResponse(items = listOf(label("team"), label("env")), total = 2),
+        )
+
+        val vm = RepoLabelsViewModel(mockApiClient)
+        vm.load(repoKey)
+
+        coVerify { mockLabelsApi.listRepoLabels(repoKey) }
+        assertEquals(listOf("env", "team"), vm.uiState.value.labels.map { it.key })
+        assertFalse(vm.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `load sets error on failure`() = runTest {
+        coEvery { mockLabelsApi.listRepoLabels(repoKey) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = RepoLabelsViewModel(mockApiClient)
+        vm.load(repoKey)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `addLabel posts key and value then reloads`() = runTest {
+        coEvery { mockLabelsApi.addRepoLabel(repoKey, "env", AddLabelRequest(value = "prod")) } returns
+            Response.success(label("env", "prod"))
+        coEvery { mockLabelsApi.listRepoLabels(repoKey) } returns Response.success(
+            LabelsListResponse(items = listOf(label("env", "prod")), total = 1),
+        )
+
+        val vm = RepoLabelsViewModel(mockApiClient)
+        vm.addLabel(repoKey, key = "env", value = "prod")
+
+        coVerify { mockLabelsApi.addRepoLabel(repoKey, "env", AddLabelRequest(value = "prod")) }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `addLabel sets error on failure`() = runTest {
+        coEvery { mockLabelsApi.addRepoLabel(repoKey, "env", any()) } returns
+            Response.error(400, okhttp3.ResponseBody.create(null, "bad"))
+
+        val vm = RepoLabelsViewModel(mockApiClient)
+        vm.addLabel(repoKey, key = "env", value = "prod")
+
+        assertNotNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `deleteLabel calls api with key then reloads`() = runTest {
+        coEvery { mockLabelsApi.deleteRepoLabel(repoKey, "env") } returns Response.success(Unit)
+        coEvery { mockLabelsApi.listRepoLabels(repoKey) } returns Response.success(
+            LabelsListResponse(items = emptyList(), total = 0),
+        )
+
+        val vm = RepoLabelsViewModel(mockApiClient)
+        vm.deleteLabel(repoKey, key = "env")
+
+        coVerify { mockLabelsApi.deleteRepoLabel(repoKey, "env") }
+        assertTrue(vm.uiState.value.labels.isEmpty())
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `deleteLabel sets error on failure`() = runTest {
+        coEvery { mockLabelsApi.deleteRepoLabel(repoKey, "env") } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = RepoLabelsViewModel(mockApiClient)
+        vm.deleteLabel(repoKey, key = "env")
+
+        assertNotNull(vm.uiState.value.error)
+    }
+}

--- a/app/src/test/java/com/artifactkeeper/android/RepoTokensViewModelTest.kt
+++ b/app/src/test/java/com/artifactkeeper/android/RepoTokensViewModelTest.kt
@@ -1,0 +1,190 @@
+package com.artifactkeeper.android
+
+import com.artifactkeeper.android.data.api.ApiClient
+import com.artifactkeeper.android.ui.screens.repositories.RepoTokensUiState
+import com.artifactkeeper.android.ui.screens.repositories.RepoTokensViewModel
+import com.artifactkeeper.client.apis.RepositoryTokensApi
+import com.artifactkeeper.client.models.CreateRepoTokenRequest
+import com.artifactkeeper.client.models.CreateRepoTokenResponse
+import com.artifactkeeper.client.models.RepoTokenListResponse
+import com.artifactkeeper.client.models.RepoTokenResponse
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RepoTokensViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val mockTokensApi = mockk<RepositoryTokensApi>()
+    private val mockApiClient = mockk<ApiClient> {
+        every { repositoryTokensApi } returns mockTokensApi
+    }
+
+    private val repoKey = "maven-releases"
+    private val now: OffsetDateTime = OffsetDateTime.parse("2026-06-22T10:00:00Z")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun token(
+        name: String,
+        revoked: Boolean = false,
+        id: UUID = UUID.randomUUID(),
+    ) = RepoTokenResponse(
+        createdAt = now,
+        id = id,
+        isExpired = false,
+        isRevoked = revoked,
+        name = name,
+        scopes = listOf("read", "write"),
+        tokenPrefix = "ak_${name.take(4)}",
+    )
+
+    @Test
+    fun `initial state is empty`() {
+        val state = RepoTokensUiState()
+        assertTrue(state.tokens.isEmpty())
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertNull(state.newTokenSecret)
+    }
+
+    @Test
+    fun `load populates tokens active first`() = runTest {
+        coEvery { mockTokensApi.listRepoTokens(repoKey) } returns Response.success(
+            RepoTokenListResponse(items = listOf(token("revoked", revoked = true), token("live"))),
+        )
+
+        val vm = RepoTokensViewModel(mockApiClient)
+        vm.load(repoKey)
+
+        coVerify { mockTokensApi.listRepoTokens(repoKey) }
+        assertEquals(2, vm.uiState.value.tokens.size)
+        assertFalse(vm.uiState.value.tokens.first().isRevoked)
+    }
+
+    @Test
+    fun `load sets error on failure`() = runTest {
+        coEvery { mockTokensApi.listRepoTokens(repoKey) } returns
+            Response.error(500, okhttp3.ResponseBody.create(null, "boom"))
+
+        val vm = RepoTokensViewModel(mockApiClient)
+        vm.load(repoKey)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `loadTokenDetail fetches a single token by id`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockTokensApi.getRepoToken(repoKey, id) } returns Response.success(token("detail", id = id))
+
+        val vm = RepoTokensViewModel(mockApiClient)
+        vm.loadTokenDetail(repoKey, id)
+
+        coVerify { mockTokensApi.getRepoToken(repoKey, id) }
+        assertEquals("detail", vm.tokenDetailState.value.token?.name)
+    }
+
+    @Test
+    fun `loadTokenDetail sets error on failure`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockTokensApi.getRepoToken(repoKey, id) } returns
+            Response.error(404, okhttp3.ResponseBody.create(null, "missing"))
+
+        val vm = RepoTokensViewModel(mockApiClient)
+        vm.loadTokenDetail(repoKey, id)
+
+        assertNotNull(vm.tokenDetailState.value.error)
+    }
+
+    @Test
+    fun `createToken posts request and exposes the one-time secret`() = runTest {
+        val request = CreateRepoTokenRequest(
+            name = "ci",
+            scopes = listOf("read", "write"),
+            expiresInDays = 30,
+        )
+        coEvery { mockTokensApi.createRepoToken(repoKey, request) } returns Response.success(
+            CreateRepoTokenResponse(
+                id = UUID.randomUUID(),
+                name = "ci",
+                repositoryKey = repoKey,
+                token = "ak_secret_value",
+            ),
+        )
+        coEvery { mockTokensApi.listRepoTokens(repoKey) } returns Response.success(
+            RepoTokenListResponse(items = listOf(token("ci"))),
+        )
+
+        val vm = RepoTokensViewModel(mockApiClient)
+        vm.createToken(repoKey, name = "ci", scopes = listOf("read", "write"), expiresInDays = 30)
+
+        coVerify { mockTokensApi.createRepoToken(repoKey, request) }
+        assertEquals("ak_secret_value", vm.uiState.value.newTokenSecret)
+    }
+
+    @Test
+    fun `createToken sets error on failure`() = runTest {
+        coEvery { mockTokensApi.createRepoToken(repoKey, any()) } returns
+            Response.error(400, okhttp3.ResponseBody.create(null, "bad"))
+
+        val vm = RepoTokensViewModel(mockApiClient)
+        vm.createToken(repoKey, name = "ci", scopes = listOf("read"), expiresInDays = null)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+
+    @Test
+    fun `revokeToken calls api with id then reloads`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockTokensApi.revokeRepoToken(repoKey, id) } returns Response.success(Unit)
+        coEvery { mockTokensApi.listRepoTokens(repoKey) } returns Response.success(
+            RepoTokenListResponse(items = listOf(token("ci", revoked = true, id = id))),
+        )
+
+        val vm = RepoTokensViewModel(mockApiClient)
+        vm.revokeToken(repoKey, id)
+
+        coVerify { mockTokensApi.revokeRepoToken(repoKey, id) }
+        assertNotNull(vm.uiState.value.message)
+    }
+
+    @Test
+    fun `revokeToken sets error on failure`() = runTest {
+        val id = UUID.randomUUID()
+        coEvery { mockTokensApi.revokeRepoToken(repoKey, id) } returns
+            Response.error(409, okhttp3.ResponseBody.create(null, "conflict"))
+
+        val vm = RepoTokensViewModel(mockApiClient)
+        vm.revokeToken(repoKey, id)
+
+        assertNotNull(vm.uiState.value.error)
+    }
+}


### PR DESCRIPTION
## Summary
Adds Labels and Access tokens entries to the repository detail screen, each opening a dedicated screen with its own HiltViewModel.

Resolved ops (real-method coVerify tests with runtime ids):
- RepositoryLabelsApi: `listRepoLabels`, `addRepoLabel(key, body)`, `deleteRepoLabel(key)`
- RepositoryTokensApi: `listRepoTokens`, `getRepoToken(id)` (detail loaded by id on entry), `createRepoToken` (plaintext token shown once), `revokeRepoToken(id)`

New nav routes: `repos/{key}/labels`, `repos/{key}/tokens`. Registers `RepositoryLabelsApi` and `RepositoryTokensApi` in `ApiClient`.

Deferred: `setRepoLabels` (bulk replacement).

## Test Checklist
- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## Platform
- [ ] Tested on emulator
- [ ] Tested on physical device (if available)
- [x] Compose previews render correctly
- [x] Accessibility content descriptions present
- [ ] N/A - no UI changes

Closes #126
Part of #80